### PR TITLE
Fix launch bounds for cleanup(...) call

### DIFF
--- a/csrc/multi_tensor_l2norm_kernel.cu
+++ b/csrc/multi_tensor_l2norm_kernel.cu
@@ -194,7 +194,11 @@ struct MaxNormFunctor
 };
 
 
-__global__ void cleanup(
+__global__ void
+#ifdef __HIP_PLATFORM_HCC__
+__launch_bounds__(1024)
+#endif
+cleanup(
   float* output,
   float* output_per_tensor,
   float* ret,
@@ -231,7 +235,11 @@ __global__ void cleanup(
   }
 }
 
-__global__ void cleanup_v2(
+__global__ void
+#ifdef __HIP_PLATFORM_HCC__
+__launch_bounds__(1024)
+#endif
+cleanup_v2(
   float* output,
   float* output_per_tensor,
   float* ret,


### PR DESCRIPTION
This PR sets launch bound for cleanup(...) kernel to 1024 because of the assumption of the number of threads in the kernel to be greater than default launch bounds on ROCm