### PR TITLE
Fix reduce_block_into_lanes for multi_tensor_l2norm for ROCm

### DIFF
--- a/tests/L0/run_amp/test_multi_tensor_l2norm.py
+++ b/tests/L0/run_amp/test_multi_tensor_l2norm.py
@@ -58,7 +58,6 @@ class TestMultiTensorL2Norm(unittest.TestCase):
         self.assertTrue(self.overflow_buf.item() == 0)
 
     @unittest.skipIf(disabled, "amp_C is unavailable")
-    @skipIfRocm
     def test_fuzz(self):
         input_size_pairs = (
             (7777*77, 555*555),


### PR DESCRIPTION
This PR fixes the warp size for ROCm in the reduce_block_into_lanes function.  It uses the warpSize variable to compute the reduction scope instead of using the fixed warp size of 32.  Since this function is used by multi_tensor_l2norm, this PR should also fix the correctness of multi_tensor_l2norm.