### PR TITLE
Skip failing unit tests

### DIFF
--- a/tests/L0/run_amp/test_basic_casts.py
+++ b/tests/L0/run_amp/test_basic_casts.py
@@ -74,11 +74,11 @@ class TestBasicCastsHalf(_TestBasicCasts):
     def tearDown(self):
         self.handle._deactivate()
     
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_linear_is_half(self):
         self._test_linear(ALWAYS_HALF)
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_conv2d_is_half(self):
         self._test_conv2d(ALWAYS_HALF)
 

--- a/tests/L0/run_amp/test_basic_casts.py
+++ b/tests/L0/run_amp/test_basic_casts.py
@@ -73,10 +73,12 @@ class TestBasicCastsHalf(_TestBasicCasts):
 
     def tearDown(self):
         self.handle._deactivate()
-
+    
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_linear_is_half(self):
         self._test_linear(ALWAYS_HALF)
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_conv2d_is_half(self):
         self._test_conv2d(ALWAYS_HALF)
 

--- a/tests/L0/run_amp/test_cache.py
+++ b/tests/L0/run_amp/test_cache.py
@@ -138,6 +138,7 @@ class TestCache(unittest.TestCase):
     def test_whitelist_module_bfp16_weight(self):
         self.train_eval_train_test(WhitelistModule, torch.bfloat16, "O4")
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_whitelist_module_fp32_weight(self):
         self.train_eval_train_test(WhitelistModule, torch.float32, "O4")
 

--- a/tests/L0/run_amp/test_cache.py
+++ b/tests/L0/run_amp/test_cache.py
@@ -138,7 +138,7 @@ class TestCache(unittest.TestCase):
     def test_whitelist_module_bfp16_weight(self):
         self.train_eval_train_test(WhitelistModule, torch.bfloat16, "O4")
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_whitelist_module_fp32_weight(self):
         self.train_eval_train_test(WhitelistModule, torch.float32, "O4")
 

--- a/tests/L0/run_amp/test_checkpointing.py
+++ b/tests/L0/run_amp/test_checkpointing.py
@@ -69,7 +69,7 @@ class TestCheckpointing(unittest.TestCase):
                     'key: {}\nparam: {}\nrestored: {}\ndiff: {} for {}'.format(
                         key, paramA, paramB, paramA - paramB, test_setup))
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_restoring(self):
         nb_epochs = 10
         nb_epochs_restore = nb_epochs // 2
@@ -221,7 +221,7 @@ class TestCheckpointing(unittest.TestCase):
                 unskipped_target = 0
                 self.assertEqual(scaler['unskipped'], unskipped_target)
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_state_dict(self):
         for opt_level in self.test_opt_levels:
             # Skip O3

--- a/tests/L0/run_amp/test_checkpointing.py
+++ b/tests/L0/run_amp/test_checkpointing.py
@@ -69,6 +69,7 @@ class TestCheckpointing(unittest.TestCase):
                     'key: {}\nparam: {}\nrestored: {}\ndiff: {} for {}'.format(
                         key, paramA, paramB, paramA - paramB, test_setup))
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_restoring(self):
         nb_epochs = 10
         nb_epochs_restore = nb_epochs // 2
@@ -220,6 +221,7 @@ class TestCheckpointing(unittest.TestCase):
                 unskipped_target = 0
                 self.assertEqual(scaler['unskipped'], unskipped_target)
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_state_dict(self):
         for opt_level in self.test_opt_levels:
             # Skip O3

--- a/tests/L0/run_amp/test_rnn.py
+++ b/tests/L0/run_amp/test_rnn.py
@@ -39,18 +39,18 @@ class TestRnnCells(unittest.TestCase):
             outputs[-1].float().sum().backward()
             for i, x in enumerate(xs):
                 self.assertEqual(x.grad.dtype, x.dtype)
-
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_rnn_cell_is_half(self):
         cell = nn.RNNCell(self.h, self.h)
         self.run_cell_test(cell)
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_gru_cell_is_half(self):
         cell = nn.GRUCell(self.h, self.h)
         self.run_cell_test(cell)
 
-    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
+    @unittest.skip("The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Same error is also observed on CUDA. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/62")
     def test_lstm_cell_is_half(self):
         cell = nn.LSTMCell(self.h, self.h)
         self.run_cell_test(cell, state_tuple=True)

--- a/tests/L0/run_amp/test_rnn.py
+++ b/tests/L0/run_amp/test_rnn.py
@@ -40,14 +40,17 @@ class TestRnnCells(unittest.TestCase):
             for i, x in enumerate(xs):
                 self.assertEqual(x.grad.dtype, x.dtype)
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_rnn_cell_is_half(self):
         cell = nn.RNNCell(self.h, self.h)
         self.run_cell_test(cell)
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_gru_cell_is_half(self):
         cell = nn.GRUCell(self.h, self.h)
         self.run_cell_test(cell)
 
+    @unittest.skip("The failing unit test is introduced by new PyTorch commit as of 12/1/2021. Same error is also observed on CUDA.")
     def test_lstm_cell_is_half(self):
         cell = nn.LSTMCell(self.h, self.h)
         self.run_cell_test(cell, state_tuple=True)

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -97,7 +97,7 @@ class TestFusedAdam(TestFusedOptimizer):
     def test_float(self):
         self.gen_single_type_test(param_type=torch.float)
     
-    @unittest.skip("NaN issue observed on ROCm as of 12/1/2021.")
+    @unittest.skip("NaN issue observed on ROCm as of 12/1/2021. The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/63")
     def test_half(self):
         self.gen_single_type_test(param_type=torch.float16)
 

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -96,7 +96,8 @@ class TestFusedAdam(TestFusedOptimizer):
 
     def test_float(self):
         self.gen_single_type_test(param_type=torch.float)
-
+    
+    @unittest.skip("NaN issue observed on ROCm as of 12/1/2021.")
     def test_half(self):
         self.gen_single_type_test(param_type=torch.float16)
 


### PR DESCRIPTION
The failing unit tests introduced by the new PyTorch commits related to "if cached_x.grad_fn.next_functions[1][0].variable is not x: IndexError: tuple index out of range" also observed on CUDA (upstream). We will first skip the following unit tests and re-enable them later.
- test_conv2d_is_half (test_basic_casts.TestBasicCastsHalf)
- test_linear_is_half (test_basic_casts.TestBasicCastsHalf)
- test_whitelist_module_fp32_weight (test_cache.TestCache)
- test_restoring (test_checkpointing.TestCheckpointing)
- test_state_dict (test_checkpointing.TestCheckpointing)
- test_gru_cell_is_half (test_rnn.TestRnnCells)
- test_lstm_cell_is_half (test_rnn.TestRnnCells)
- test_rnn_cell_is_half (test_rnn.TestRnnCells)

Additionally, the failing test for test_half (test_fused_optimizer.TestFusedAdam) is only observed on ROCm. There are some NaNs "sporadically" (99% values are correct compared to the outputs with torch.optim.Adam) showing in the outputs after apex.optimizers.FusedAdam is called to update its parameters. We are currently looking into the issue.