### PR TITLE
Cherry-pick b2fdf9c from upstream Apex and resolve conflicts

### DIFF
--- a/apex/contrib/csrc/fmha/src/fmha.h
+++ b/apex/contrib/csrc/fmha/src/fmha.h
@@ -30,7 +30,12 @@
 #include <cuda.h>
 #include <vector>
 
+#ifdef OLD_GENERATOR_PATH
+#include <ATen/CUDAGeneratorImpl.h>
+#else
 #include <ATen/cuda/CUDAGeneratorImpl.h>
+#endif
+
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 
 #include <fmha_utils.h>

--- a/apex/contrib/csrc/multihead_attn/dropout.h
+++ b/apex/contrib/csrc/multihead_attn/dropout.h
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 
-#ifdef OLD_GENERATOR
-#include <ATen/CUDAGenerator.h>
+#ifdef OLD_GENERATOR_PATH
+#include <ATen/CUDAGeneratorImpl.h>
 #else
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #endif
@@ -178,15 +178,10 @@ void apex_fused_dropout_cuda(scalar_t const *inputs, scalar_t *outputs,
   std::pair<uint64_t, uint64_t> rng_engine_inputs;
   {
     // See Note [Acquire lock when using random generators]
-#ifdef OLD_GENERATOR
-    std::lock_guard<std::mutex> lock(gen->mutex_);
-    rng_engine_inputs = gen->philox_engine_inputs(counter_offset);
-#else
     std::lock_guard<std::mutex> lock(gen.mutex());
     rng_engine_inputs =
         at::check_generator<at::CUDAGeneratorImpl>(gen)->philox_engine_inputs(
             counter_offset);
-#endif
   }
 
   apex_fused_dropout_kernel<scalar_t, accscalar_t, IndexType>
@@ -219,15 +214,10 @@ void apex_dropout_add_cuda(scalar_t const *inputs, scalar_t const *add_inputs,
   std::pair<uint64_t, uint64_t> rng_engine_inputs;
   {
     // See Note [Acquire lock when using random generators]
-#ifdef OLD_GENERATOR
-    std::lock_guard<std::mutex> lock(gen->mutex_);
-    rng_engine_inputs = gen->philox_engine_inputs(counter_offset);
-#else
     std::lock_guard<std::mutex> lock(gen.mutex());
     rng_engine_inputs =
         at::check_generator<at::CUDAGeneratorImpl>(gen)->philox_engine_inputs(
             counter_offset);
-#endif
   }
 
   apex_dropout_add_kernel<scalar_t, accscalar_t, IndexType>

--- a/apex/contrib/csrc/multihead_attn/softmax.h
+++ b/apex/contrib/csrc/multihead_attn/softmax.h
@@ -1,8 +1,13 @@
 #pragma once
 #include "philox.h"
-#include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <curand_kernel.h>
+
+#ifdef OLD_GENERATOR_PATH
+#include <ATen/CUDAGeneratorImpl.h>
+#else
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#endif
 
 #include <assert.h>
 #include <cfloat>

--- a/apex/contrib/csrc/transducer/transducer_joint_kernel.cu
+++ b/apex/contrib/csrc/transducer/transducer_joint_kernel.cu
@@ -4,7 +4,13 @@
 
 #include <torch/extension.h>
 #include <ATen/AccumulateType.h>
+
+#ifdef OLD_GENERATOR_PATH
+#include <ATen/CUDAGeneratorImpl.h>
+#else
 #include <ATen/cuda/CUDAGeneratorImpl.h>
+#endif
+
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <c10/macros/Macros.h>

--- a/setup.py
+++ b/setup.py
@@ -362,11 +362,12 @@ if "--deprecated_fused_lamb" in sys.argv or "--cuda_ext" in sys.argv:
                           include_dirs=[os.path.join(this_dir, 'csrc')],
                           extra_compile_args = nvcc_args_fused_lamb if not IS_ROCM_PYTORCH else hipcc_args_fused_lamb))
 
-# Check, if ATen/CUDAGenerator.h is found, otherwise use the new ATen/CUDAGeneratorImpl.h, due to breaking change in https://github.com/pytorch/pytorch/pull/36026
+# Check, if ATen/CUDAGeneratorImpl.h is found, otherwise use ATen/cuda/CUDAGeneratorImpl.h
+# See https://github.com/pytorch/pytorch/pull/70650
 generator_flag = []
 torch_dir = torch.__path__[0]
-if os.path.exists(os.path.join(torch_dir, 'include', 'ATen', 'CUDAGenerator.h')):
-    generator_flag = ['-DOLD_GENERATOR']
+if os.path.exists(os.path.join(torch_dir, "include", "ATen", "CUDAGeneratorImpl.h")):
+    generator_flag = ["-DOLD_GENERATOR_PATH"]
 
 if "--fast_layer_norm" in sys.argv:
     sys.argv.remove("--fast_layer_norm")


### PR DESCRIPTION
This fixes Apex build issues with older PyTorch versions 1.8.1, 1.9 and 1.10, since they didn't have the `ATen/cuda/CUDAGeneratorImpl.h` file available.

```
15:05:31  [0m[91m    In file included from /tmp/pip-req-build-sttueip5/apex/contrib/csrc/multihead_attn/additive_masked_softmax_dropout_hip.hip:15:
15:05:31      /tmp/pip-req-build-sttueip5/apex/contrib/csrc/multihead_attn/dropout_hip.h:8:10: fatal error: 'ATen/hip/HIPGeneratorImpl.h' file not found
15:05:31      #include <ATen/hip/HIPGeneratorImpl.h>
```