### PR TITLE
Make rocblas_gemm_flags_fp16_alt_impl backward-compat for new naming

### DIFF
--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
@@ -325,8 +325,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
@@ -326,10 +326,7 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
@@ -382,14 +382,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif
-  
+
   // Dropout Add Backward  
   apex_masked_scale_cuda<at::Half,float,uint32_t>(
                              static_cast<at::Half const*>(output_grads.data_ptr()),

--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
@@ -381,8 +381,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
@@ -280,8 +280,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
@@ -281,10 +281,7 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
@@ -280,8 +280,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
@@ -281,10 +281,7 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
@@ -276,8 +276,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
@@ -277,10 +277,7 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
@@ -328,10 +328,7 @@ std::vector<torch::Tensor> bwd_cuda(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flags = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
@@ -327,8 +327,11 @@ std::vector<torch::Tensor> bwd_cuda(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flags = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flags = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/csrc/mlp_cuda.cu
+++ b/csrc/mlp_cuda.cu
@@ -1510,8 +1510,11 @@ int mlp_bp(
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
-      #ifdef ROCM_BACKWARD_PASS_GUARD
+      #ifdef BACKWARD_PASS_GUARD
         flag = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+      #endif
+      #ifdef ROCM_BACKWARD_PASS_GUARD
+        flag = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/csrc/mlp_cuda.cu
+++ b/csrc/mlp_cuda.cu
@@ -1511,10 +1511,7 @@ int mlp_bp(
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL
       #ifdef BACKWARD_PASS_GUARD
-        flag = at::BackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
-      #endif
-      #ifdef ROCM_BACKWARD_PASS_GUARD
-        flag = at::ROCmBackwardPassGuard::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
+        flag = at::BACKWARD_PASS_GUARD_CLASS::is_backward_pass() ? rocblas_gemm_flags_fp16_alt_impl : 0;
       #endif
     #endif
   #endif

--- a/setup.py
+++ b/setup.py
@@ -253,9 +253,10 @@ if "--cuda_ext" in sys.argv:
 
         hipcc_args_mlp = ['-O3'] + version_dependent_macros
         if found_Backward_Pass_Guard:
-            hipcc_args_mlp = hipcc_args_mlp + ['-DBACKWARD_PASS_GUARD']
+            hipcc_args_mlp = hipcc_args_mlp + ['-DBACKWARD_PASS_GUARD'] + ['-DBACKWARD_PASS_GUARD_CLASS=BackwardPassGuard']
         if found_ROCmBackward_Pass_Guard:
-            hipcc_args_mlp = hipcc_args_mlp + ['-DROCM_BACKWARD_PASS_GUARD']
+            hipcc_args_mlp = hipcc_args_mlp + ['-DBACKWARD_PASS_GUARD'] + ['-DBACKWARD_PASS_GUARD_CLASS=ROCmBackwardPassGuard']
+
         print ("INFO: Building the MLP Extension.")
         ext_modules.append(
             CUDAExtension(name='mlp_cuda',
@@ -504,10 +505,9 @@ if "--fast_multihead_attn" in sys.argv or "--cuda_ext" in sys.argv:
                           '-U__HIP_NO_HALF_OPERATORS__',
                           '-U__HIP_NO_HALF_CONVERSIONS__'] + version_dependent_macros + generator_flag
         if found_Backward_Pass_Guard:
-            hipcc_args_mha = hipcc_args_mha + ['-DBACKWARD_PASS_GUARD']
+            hipcc_args_mha = hipcc_args_mha + ['-DBACKWARD_PASS_GUARD'] + ['-DBACKWARD_PASS_GUARD_CLASS=BackwardPassGuard']
         if found_ROCmBackward_Pass_Guard:
-            hipcc_args_mha = hipcc_args_mha + ['-DROCM_BACKWARD_PASS_GUARD']
-
+            hipcc_args_mha = hipcc_args_mha + ['-DBACKWARD_PASS_GUARD'] + ['-DBACKWARD_PASS_GUARD_CLASS=ROCmBackwardPassGuard']
 
         ext_modules.append(
             CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,15 @@ context_file = os.path.join(torch_dir, "include", "ATen", "Context.h")
 if os.path.exists(context_file):
     lines = open(context_file, 'r').readlines()
     found_Backward_Pass_Guard = False
+    found_ROCmBackward_Pass_Guard = False
     for line in lines:
         if "BackwardPassGuard" in line:
-            found_Backward_Pass_Guard = True
+            # BackwardPassGuard has been renamed to ROCmBackwardPassGuard
+            # https://github.com/pytorch/pytorch/pull/71881/commits/4b82f5a67a35406ffb5691c69e6b4c9086316a43
+            if "ROCmBackwardPassGuard" in line:
+                found_ROCmBackward_Pass_Guard = True
+            else:
+                found_Backward_Pass_Guard = True
             break
 
 def get_cuda_bare_metal_version(cuda_dir):
@@ -245,6 +251,11 @@ if "--cuda_ext" in sys.argv:
                           extra_compile_args={'cxx': ['-O3'] + version_dependent_macros,
                                               'nvcc': nvcc_args_layer_norm if not IS_ROCM_PYTORCH else hipcc_args_layer_norm}))
 
+        hipcc_args_mlp = ['-O3'] + version_dependent_macros
+        if found_Backward_Pass_Guard:
+            hipcc_args_mlp = hipcc_args_mlp + ['-DBACKWARD_PASS_GUARD']
+        if found_ROCmBackward_Pass_Guard:
+            hipcc_args_mlp = hipcc_args_mlp + ['-DROCM_BACKWARD_PASS_GUARD']
         print ("INFO: Building the MLP Extension.")
         ext_modules.append(
             CUDAExtension(name='mlp_cuda',
@@ -252,8 +263,8 @@ if "--cuda_ext" in sys.argv:
                                    'csrc/mlp_cuda.cu'],
                           include_dirs=[os.path.join(this_dir, 'csrc')],
                           extra_compile_args={'cxx': ['-O3'] + version_dependent_macros,
-                                              'nvcc':['-O3'] + version_dependent_macros if not found_Backward_Pass_Guard 
-                                              else ['-O3'] + version_dependent_macros + ['-DROCM_BACKWARD_PASS_GUARD']}))
+                                              'nvcc':['-O3'] + version_dependent_macros
+                                              if not IS_ROCM_PYTORCH else hipcc_args_mlp}))
 
         ext_modules.append(
             CUDAExtension(name='fused_dense_cuda',
@@ -493,7 +504,10 @@ if "--fast_multihead_attn" in sys.argv or "--cuda_ext" in sys.argv:
                           '-U__HIP_NO_HALF_OPERATORS__',
                           '-U__HIP_NO_HALF_CONVERSIONS__'] + version_dependent_macros + generator_flag
         if found_Backward_Pass_Guard:
+            hipcc_args_mha = hipcc_args_mha + ['-DBACKWARD_PASS_GUARD']
+        if found_ROCmBackward_Pass_Guard:
             hipcc_args_mha = hipcc_args_mha + ['-DROCM_BACKWARD_PASS_GUARD']
+
 
         ext_modules.append(
             CUDAExtension(


### PR DESCRIPTION
As [the PR](https://github.com/pytorch/pytorch/pull/71881/files) in PyTorch upstream for rocblas_gemm_flags_fp16_alt_impl (used in Apex MHA and MLP extensions) has renamed BackwardPassGuard to ROCmBackwardPassGuard, the changes in this PR can prevent the backward-breaking issues.

