### PR TITLE
Enable --peer_memory and --nccl p2p extensions for ROCm

### DIFF
--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -107,15 +107,10 @@ class HaloExchangerPeer(HaloExchanger):
         right_tx = self.peer_pool.allocate_peer_tensors(list(right_output_halo.shape), right_output_halo.dtype, channels_last, True)
         pm.push_pull_halos_1d(
                 self.diagnostics, self.explicit_nhwc, self.numSM,
-                left_output_halo,  left_tx[self.rank_in_group],  right_tx[self.wrap_around_left_rank_in_group], left_input_halo,
-                right_output_halo, right_tx[self.rank_in_group], left_tx[self.wrap_around_right_rank_in_group],  right_input_halo,
+                self.left_zero, left_output_halo,  left_tx[self.rank_in_group],  right_tx[self.wrap_around_left_rank_in_group], left_input_halo,
+                self.right_zero, right_output_halo, right_tx[self.rank_in_group], left_tx[self.wrap_around_right_rank_in_group],  right_input_halo,
                 self.signals[self.wrap_around_left_rank_in_group], self.signals[self.wrap_around_right_rank_in_group], self.signals[self.rank_in_group]
                 )
-        # TODO: Add to push_pull_halos_1d kernel
-        if self.left_zero:
-            left_input_halo.zero_()
-        if self.right_zero:
-            right_input_halo.zero_()
         if not inplace:
             return left_input_halo, right_input_halo
 

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
@@ -5,7 +5,11 @@
 #include <cstdio>
 #include <ctime>
 #include <cassert>
+#ifdef __HIP_PLATFORM_HCC__
+#include "rccl.h"
+#else
 #include "nccl.h"
+#endif
 
 /*
  * This file implements a crude but effective mechanism for copying data between tenors owned by different ranks

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -32,10 +32,12 @@ namespace apex { namespace contrib { namespace peer_memory {
         bool diagnostics,
         bool explicit_nhwc,
         int numSM,                      // number of SMs to use
+	bool top_zero,			// true if top halo should be zeroed
         at::Tensor top_out_halo,        // top output halo in sender device memory
         at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
 	at::Tensor top_inp_tx,		// top input transfer buffer in top neighbor peer pool memory
         at::Tensor top_inp_halo,        // top input halo in receiver device memory
+	bool btm_zero,			// true if btm halo should be zeroed
         at::Tensor btm_out_halo,        // btm output halo in sender device memory
         at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
 	at::Tensor btm_inp_tx,		// btm input transfer buffer in btm neighbor peer pool memory

--- a/apex/contrib/peer_memory/__init__.py
+++ b/apex/contrib/peer_memory/__init__.py
@@ -1,2 +1,3 @@
 from .peer_memory import PeerMemoryPool
 from .peer_halo_exchanger_1d import PeerHaloExchanger1d
+

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -3,9 +3,15 @@ from apex.contrib.peer_memory import PeerMemoryPool
 import peer_memory_cuda as pm
 
 class PeerHaloExchanger1d:
-    def __init__(self, rank, peer_group_size, peer_pool, half_halo):
-        self.peer_group_size = peer_group_size
-        self.peer_rank = rank % peer_group_size
+    def __init__(self, ranks, rank_in_group, peer_pool, half_halo):
+        self.peer_group_size = len(ranks)
+        self.ranks = ranks
+        self.peer_rank = rank_in_group
+        self.low_neighbor = (self.peer_rank + self.peer_group_size - 1) % self.peer_group_size
+        self.high_neighbor = (self.peer_rank + 1) % self.peer_group_size
+        self.low_zero = True if self.peer_rank == 0 else False
+        self.high_zero = True if self.peer_rank == self.peer_group_size - 1 else False
+
         self.peer_pool = peer_pool
         self.signals = peer_pool.allocate_peer_tensors([2,4], torch.int32, False, False)
         self.signals[self.peer_rank].zero_()
@@ -17,45 +23,43 @@ class PeerHaloExchanger1d:
             if explicit_nhwc:
                 _, Hs, _, _ = list(y.shape)
                 H = Hs - 2*self.half_halo
-                top_out_halo = y[:,self.half_halo:2*self.half_halo,:,:]
-                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
-                top_inp_halo = y[:,:self.half_halo,:,:]
-                btm_out_halo = y[:,H:H+self.half_halo,:,:]
-                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
-                btm_inp_halo = y[:,H+self.half_halo:H+2*self.half_halo,:,:]
+                low_out_halo = y[:,self.half_halo:2*self.half_halo,:,:]
+                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, False, True)
+                low_inp_halo = y[:,:self.half_halo,:,:]
+                high_out_halo = y[:,H:H+self.half_halo,:,:]
+                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, False, True)
+                high_inp_halo = y[:,H+self.half_halo:H+2*self.half_halo,:,:]
             else:
                 _, _, Hs, _ = list(y.shape)
                 H = Hs - 2*self.half_halo
-                top_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
-                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
-                top_inp_halo = y[:,:,:self.half_halo,:]
-                btm_out_halo = y[:,:,H:H+self.half_halo,:]
-                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
-                btm_inp_halo = y[:,:,H+self.half_halo:H+2*self.half_halo,:]
+                low_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
+                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, channels_last, True)
+                low_inp_halo = y[:,:,:self.half_halo,:]
+                high_out_halo = y[:,:,H:H+self.half_halo,:]
+                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, channels_last, True)
+                high_inp_halo = y[:,:,H+self.half_halo:H+2*self.half_halo,:]
         else:
             if explicit_nhwc:
                 _, _, Ws, _ = list(y.shape)
                 W = Ws - 2*self.half_halo
-                top_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
-                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
-                top_inp_halo = y[:,:,:self.half_halo,:]
-                btm_out_halo = y[:,:,W:W+self.half_halo,:]
-                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
-                btm_inp_halo = y[:,:,W+self.half_halo:W+2*self.half_halo,:]
+                low_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
+                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, False, True)
+                low_inp_halo = y[:,:,:self.half_halo,:]
+                high_out_halo = y[:,:,W:W+self.half_halo,:]
+                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, False, True)
+                high_inp_halo = y[:,:,W+self.half_halo:W+2*self.half_halo,:]
             else:
                 _, _, _, Ws = list(y.shape)
                 W = Ws - 2*self.half_halo
-                top_out_halo = y[:,:,:,self.half_halo:2*self.half_halo]
-                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
-                top_inp_halo = y[:,:,:,:self.half_halo]
-                btm_out_halo = y[:,:,:,W:W+self.half_halo]
-                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
-                btm_inp_halo = y[:,:,:,W+self.half_halo:W+2*self.half_halo]
-        top_neighbor = (self.peer_rank + self.peer_group_size - 1) % self.peer_group_size
-        btm_neighbor = (self.peer_rank + 1) % self.peer_group_size
+                low_out_halo = y[:,:,:,self.half_halo:2*self.half_halo]
+                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, channels_last, True)
+                low_inp_halo = y[:,:,:,:self.half_halo]
+                high_out_halo = y[:,:,:,W:W+self.half_halo]
+                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, channels_last, True)
+                high_inp_halo = y[:,:,:,W+self.half_halo:W+2*self.half_halo]
         pm.push_pull_halos_1d(
                 diagnostics, explicit_nhwc, numSM,
-                top_out_halo, top_tx[self.peer_rank], btm_tx[top_neighbor], top_inp_halo, 
-                btm_out_halo, btm_tx[self.peer_rank], top_tx[btm_neighbor], btm_inp_halo,
-                self.signals[top_neighbor], self.signals[btm_neighbor], self.signals[self.peer_rank]
+                self.low_zero, low_out_halo, low_tx[self.peer_rank], high_tx[self.low_neighbor], low_inp_halo, 
+                self.high_zero, high_out_halo, high_tx[self.peer_rank], low_tx[self.high_neighbor], high_inp_halo,
+                self.signals[self.low_neighbor], self.signals[self.high_neighbor], self.signals[self.peer_rank]
                 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,55 @@ def get_cuda_bare_metal_version(cuda_dir):
 
     return raw_output, bare_metal_major, bare_metal_minor
 
+
+def check_cuda_torch_binary_vs_bare_metal(cuda_dir):
+    raw_output, bare_metal_major, bare_metal_minor = get_cuda_bare_metal_version(cuda_dir)
+    torch_binary_major = torch.version.cuda.split(".")[0]
+    torch_binary_minor = torch.version.cuda.split(".")[1]
+
+    print("\nCompiling cuda extensions with")
+    print(raw_output + "from " + cuda_dir + "/bin\n")
+
+    if (bare_metal_major != torch_binary_major) or (bare_metal_minor != torch_binary_minor):
+        raise RuntimeError(
+            "Cuda extensions are being compiled with a version of Cuda that does "
+            "not match the version used to compile Pytorch binaries.  "
+            "Pytorch binaries were compiled with Cuda {}.\n".format(torch.version.cuda)
+            + "In some cases, a minor-version mismatch will not cause later errors:  "
+            "https://github.com/NVIDIA/apex/pull/323#discussion_r287021798.  "
+            "You can try commenting out this check (at your own risk)."
+        )
+
+
+def raise_if_cuda_home_none(global_option: str) -> None:
+    if CUDA_HOME is not None:
+        return
+    raise RuntimeError(
+        f"{global_option} was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  "
+        "If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, "
+        "only images whose names contain 'devel' will provide nvcc."
+    )
+
+
+def append_nvcc_threads(nvcc_extra_args):
+    _, bare_metal_major, bare_metal_minor = get_cuda_bare_metal_version(CUDA_HOME)
+    if int(bare_metal_major) >= 11 and int(bare_metal_minor) >= 2:
+        return nvcc_extra_args + ["--threads", "4"]
+    return nvcc_extra_args
+
+
+def check_cudnn_version_and_warn(global_option: str, required_cudnn_version: int) -> bool:
+    cudnn_available = torch.backends.cudnn.is_available()
+    cudnn_version = torch.backends.cudnn.version() if cudnn_available else None
+    if not (cudnn_available and (cudnn_version >= required_cudnn_version)):
+        warnings.warn(
+            f"Skip `{global_option}` as it requires cuDNN {required_cudnn_version} or later, "
+            f"but {'cuDNN is not available' if not cudnn_available else cudnn_version}"
+        )
+        return False
+    return True
+
+
 print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))
 TORCH_MAJOR = int(torch.__version__.split('.')[0])
 TORCH_MINOR = int(torch.__version__.split('.')[1])
@@ -539,6 +588,10 @@ if "--fast_bottleneck" in sys.argv:
 if "--peer_memory" in sys.argv or "--cuda_ext" in sys.argv:
     if "--peer_memory" in sys.argv:
         sys.argv.remove("--peer_memory")
+
+    if not IS_ROCM_PYTORCH:
+        raise_if_cuda_home_none("--peer_memory")
+
     ext_modules.append(
         CUDAExtension(
             name="peer_memory_cuda",
@@ -553,6 +606,10 @@ if "--peer_memory" in sys.argv or "--cuda_ext" in sys.argv:
 if "--nccl_p2p" in sys.argv or "--cuda_ext" in sys.argv:
     if "--nccl_p2p" in sys.argv:
         sys.argv.remove("--nccl_p2p")
+
+    if not IS_ROCM_PYTORCH:
+        raise_if_cuda_home_none("--nccl_p2p")
+
     ext_modules.append(
         CUDAExtension(
             name="nccl_p2p_cuda",

--- a/setup.py
+++ b/setup.py
@@ -536,9 +536,9 @@ if "--fast_bottleneck" in sys.argv:
             )
         )
 
-if "--peer_memory" in sys.argv:
-    sys.argv.remove("--peer_memory")
-    raise_if_cuda_home_none("--peer_memory")
+if "--peer_memory" in sys.argv or "--cuda_ext" in sys.argv:
+    if "--peer_memory" in sys.argv:
+        sys.argv.remove("--peer_memory")
     ext_modules.append(
         CUDAExtension(
             name="peer_memory_cuda",
@@ -550,9 +550,9 @@ if "--peer_memory" in sys.argv:
         )
     )
 
-if "--nccl_p2p" in sys.argv:
-    sys.argv.remove("--nccl_p2p")
-    raise_if_cuda_home_none("--nccl_p2p")
+if "--nccl_p2p" in sys.argv or "--cuda_ext" in sys.argv:
+    if "--nccl_p2p" in sys.argv:
+        sys.argv.remove("--nccl_p2p")
     ext_modules.append(
         CUDAExtension(
             name="nccl_p2p_cuda",


### PR DESCRIPTION
These extensions are needed to enable the fast_bottleneck Apex extension. While there are no unit tests for these extensions, there is a test file `peer_halo_exchange_module_tests.py` added for the --peer_memory extension. The tests in that file pass on CUDA but fail inconsistently on ROCm.