### PR TITLE
Faster build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ if TORCH_MAJOR == 0 and TORCH_MINOR < 4:
         "Apex requires Pytorch 0.4 or newer.\nThe latest stable release can be obtained from https://pytorch.org/"
     )
 
-cmdclass = {}
+# cmdclass = {}
 ext_modules = []
 
 extras = {}
@@ -146,7 +146,6 @@ if "--cpp_ext" in sys.argv or "--cuda_ext" in sys.argv:
     if TORCH_MAJOR == 0:
         raise RuntimeError("--cpp_ext requires Pytorch 1.0 or later, "
                            "found torch.__version__ = {}".format(torch.__version__))
-    cmdclass['build_ext'] = BuildExtension
 if "--cpp_ext" in sys.argv:
     sys.argv.remove("--cpp_ext")
     ext_modules.append(CppExtension("apex_C", ["csrc/flatten_unflatten.cpp"]))
@@ -172,9 +171,6 @@ if "--distributed_adam" in sys.argv or "--cuda_ext" in sys.argv:
     if "--distributed_adam" in sys.argv:
         sys.argv.remove("--distributed_adam")
 
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
-
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--distributed_adam was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
     else:
@@ -193,9 +189,6 @@ if "--distributed_lamb" in sys.argv or "--cuda_ext" in sys.argv:
     from torch.utils.cpp_extension import CUDAExtension
     if "--distributed_lamb" in sys.argv:
         sys.argv.remove("--distributed_lamb")
-
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
 
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--distributed_lamb was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
@@ -315,9 +308,6 @@ if "--bnp" in sys.argv or "--cuda_ext" in sys.argv:
     if "--bnp" in sys.argv:
         sys.argv.remove("--bnp")
 
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
-
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--bnp was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
     else:
@@ -339,9 +329,6 @@ if "--xentropy" in sys.argv or "--cuda_ext" in sys.argv:
     from torch.utils.cpp_extension import CUDAExtension
     if "--xentropy" in sys.argv:
         sys.argv.remove("--xentropy")
-
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
 
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--xentropy was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
@@ -397,9 +384,6 @@ if "--deprecated_fused_adam" in sys.argv or "--cuda_ext" in sys.argv:
     if "--deprecated_fused_adam" in sys.argv:
         sys.argv.remove("--deprecated_fused_adam")
 
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
-
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--deprecated_fused_adam was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
     else:
@@ -419,9 +403,6 @@ if "--deprecated_fused_lamb" in sys.argv or "--cuda_ext" in sys.argv:
     from torch.utils.cpp_extension import CUDAExtension
     if "--deprecated_fused_lamb" in sys.argv:
         sys.argv.remove("--deprecated_fused_lamb")
-
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension
 
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--deprecated_fused_lamb was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
@@ -514,9 +495,6 @@ if "--fast_multihead_attn" in sys.argv or "--cuda_ext" in sys.argv:
     from torch.utils.cpp_extension import CUDAExtension
     if "--fast_multihead_attn" in sys.argv:
         sys.argv.remove("--fast_multihead_attn")
-
-    from torch.utils.cpp_extension import BuildExtension
-    cmdclass['build_ext'] = BuildExtension.with_options(use_ninja=False)
 
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--fast_multihead_attn was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
@@ -688,7 +666,6 @@ setup(
     ),
     description="PyTorch Extensions written by NVIDIA",
     ext_modules=ext_modules,
-    cmdclass=cmdclass,
-    #cmdclass={'build_ext': BuildExtension} if ext_modules else {},
+    cmdclass={'build_ext': BuildExtension} if ext_modules else {},
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,6 @@ if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR > 4):
 version_dependent_macros = version_ge_1_1 + version_ge_1_3 + version_ge_1_5
 
 if "--distributed_adam" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--distributed_adam" in sys.argv:
         sys.argv.remove("--distributed_adam")
 
@@ -186,7 +185,6 @@ if "--distributed_adam" in sys.argv or "--cuda_ext" in sys.argv:
                                               'nvcc':nvcc_args_adam if not IS_ROCM_PYTORCH else hipcc_args_adam}))
 
 if "--distributed_lamb" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--distributed_lamb" in sys.argv:
         sys.argv.remove("--distributed_lamb")
 
@@ -205,8 +203,6 @@ if "--distributed_lamb" in sys.argv or "--cuda_ext" in sys.argv:
                                               'nvcc': nvcc_args_distributed_lamb if not IS_ROCM_PYTORCH else hipcc_args_distributed_lamb}))
 
 if "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
-
     if torch.utils.cpp_extension.CUDA_HOME is None and not IS_ROCM_PYTORCH:
         raise RuntimeError("--cuda_ext was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, only images whose names contain 'devel' will provide nvcc.")
     else:
@@ -304,7 +300,6 @@ if "--cuda_ext" in sys.argv:
 
 
 if "--bnp" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--bnp" in sys.argv:
         sys.argv.remove("--bnp")
 
@@ -326,7 +321,6 @@ if "--bnp" in sys.argv or "--cuda_ext" in sys.argv:
                                                       '-D__CUDA_NO_HALF2_OPERATORS__'] + version_dependent_macros}))
 
 if "--xentropy" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--xentropy" in sys.argv:
         sys.argv.remove("--xentropy")
 
@@ -380,7 +374,6 @@ if "--index_mul_2d" in sys.argv or "--cuda_ext" in sys.argv:
     )
 
 if "--deprecated_fused_adam" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--deprecated_fused_adam" in sys.argv:
         sys.argv.remove("--deprecated_fused_adam")
 
@@ -400,7 +393,6 @@ if "--deprecated_fused_adam" in sys.argv or "--cuda_ext" in sys.argv:
                                               'nvcc' : nvcc_args_fused_adam if not IS_ROCM_PYTORCH else hipcc_args_fused_adam}))
 
 if "--deprecated_fused_lamb" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--deprecated_fused_lamb" in sys.argv:
         sys.argv.remove("--deprecated_fused_lamb")
 
@@ -492,7 +484,6 @@ if "--fmha" in sys.argv:
 
 
 if "--fast_multihead_attn" in sys.argv or "--cuda_ext" in sys.argv:
-    from torch.utils.cpp_extension import CUDAExtension
     if "--fast_multihead_attn" in sys.argv:
         sys.argv.remove("--fast_multihead_attn")
 


### PR DESCRIPTION
Build Apex with the original setup.py (with and without ninja for `gfx900;gfx906;gfx908;gfx90a;gfx1030`) on a system with the default MAX_JOBS=32 with the following two commands:

**1. pip install**
```
time pip install --disable-pip-version-check --global-option="--cpp_ext" --global-option="--cuda_ext" -v . 
```
**2. python setup.py install**
```
time python setup.py install --cpp_ext --cuda_ext
```
The extensions built in the experiment:

| Extension Name          | Support on ROCm |
|-------------------------|-----------------|
| --cpp_ext               | Yes             |
| --distributed_adam      | Yes             |
| --distributed_lamb      | Yes             |
| --cuda_ext              | Yes             |
| --permutation_search    | **No**          |
| --bnp                   | Yes             |
| --xentropy              | Yes             |
| --focal_loss            | Yes             |
| --index_mul_2d          | Yes             |
| --deprecated_fused_adam | Yes             |
| --deprecated_fused_lamb | Yes             |
| --fast_layer_norm       | **No**          |
| --fmha                  | **No**          |
| --fast_multihead_attn   | Yes             |
| --transducer            | Yes             |
| --fast_bottleneck       | **No**          |
| --cudnn_gbn             | **No**          |
| --peer_memory           | Yes             |
| --nccl_p2p              | Yes             |
| --fused_conv_bias_relu  | **No**          |

## Comparison of installation time:
### Original
```
real    44m19.120s
user    42m57.882s
sys     1m44.311s
```
### PR
```
real    20m31.879s
user    43m34.892s
sys     2m0.980s
```

