### PR TITLE
Unskip some unit tests related to issue #82

### DIFF
--- a/tests/L0/run_amp/test_checkpointing.py
+++ b/tests/L0/run_amp/test_checkpointing.py
@@ -228,7 +228,7 @@ class TestCheckpointing(unittest.TestCase):
                 continue
 
             model = MyModel().to('cuda')
-            optimizer = optim.Adam(model.parameters(), lr=1e-3)
+            optimizer = optim.Adam(model.parameters(), lr=1e-3, capturable=True)
             model, optimizer = amp.initialize(
                 model, optimizer, opt_level=opt_level, verbosity=0)
 

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -91,13 +91,15 @@ class TestFusedAdam(TestFusedOptimizer):
     def setUp(self):
         super().setUp()
         self.options = {'lr':5e-4, 'betas':(0.9, 0.999), 'eps':1e-08,
+            'weight_decay': 0, 'amsgrad': False, "capturable": True}
+        self.tst_options = {'lr':5e-4, 'betas':(0.9, 0.999), 'eps':1e-08,
             'weight_decay': 0, 'amsgrad': False}
         self.ref_optim = torch.optim.Adam
         self.fused_optim = apex.optimizers.FusedAdam
 
     def test_float(self):
         self.gen_single_type_test(param_type=torch.float)
-    
+
     # NOTE(mkozuki): Current threshold values look too small for BFloat16.
     # TODO(mkozuki): Refactor `TestFusedOptimizer`
     @unittest.skip("NaN issue observed on ROCm as of 12/1/2021. The failing unit test is introduced by a PyTorch commit sometime in between rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0 and 2021/12/01. Please refer to https://github.com/ROCmSoftwarePlatform/apex/issues/63")
@@ -176,11 +178,14 @@ class TestFusedAdam(TestFusedOptimizer):
     def test_adam_option(self):
         nelem = 1
         adam_option = {'lr':0.01, 'betas':(0.6, 0.9), 'eps':3e-06,
+            'weight_decay':0, 'amsgrad':False, 'capturable':True}
+
+        adam_option_tst = {'lr':0.01, 'betas':(0.6, 0.9), 'eps':3e-06,
             'weight_decay':0, 'amsgrad':False}
 
         tensor = torch.rand(nelem, dtype=torch.float, device='cuda')
         ref_param, tst_param, ref_optim, tst_optim = \
-            self.gen_param_optim([tensor], adam_option)
+            self.gen_param_optim([tensor], adam_option, adam_option_tst)
 
         for i in range(self.iters):
             self.gen_grad(ref_param, tst_param)

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -95,7 +95,6 @@ class TestFusedAdam(TestFusedOptimizer):
         self.ref_optim = torch.optim.Adam
         self.fused_optim = apex.optimizers.FusedAdam
 
-    @unittest.skip("Skipped the test since a regression introduced from PyTorch upstream: due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598. Please also refer to https://github.com/ROCmSoftwarePlatform/apex/issues/82")
     def test_float(self):
         self.gen_single_type_test(param_type=torch.float)
     
@@ -105,11 +104,9 @@ class TestFusedAdam(TestFusedOptimizer):
     def test_half(self):
         self.gen_single_type_test(param_type=torch.float16, skip_assert=True)
 
-    @unittest.skip("Skipped the test since a regression introduced from PyTorch upstream: due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598. Please also refer to https://github.com/ROCmSoftwarePlatform/apex/issues/82")
     def test_bfloat16(self):
         self.gen_single_type_test(param_type=torch.bfloat16, skip_assert=True)
 
-    @unittest.skip("Skipped the test since a regression introduced from PyTorch upstream: due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598. Please also refer to https://github.com/ROCmSoftwarePlatform/apex/issues/82")
     @unittest.skipIf(torch.cuda.device_count()<2, "more than 1 GPU required")
     def test_multi_device(self):
         devices = ("cuda:0", "cuda:1")
@@ -176,7 +173,6 @@ class TestFusedAdam(TestFusedOptimizer):
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
 
-    @unittest.skip("Skipped the test since a regression introduced from PyTorch upstream: due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598. Please also refer to https://github.com/ROCmSoftwarePlatform/apex/issues/82")
     def test_adam_option(self):
         nelem = 1
         adam_option = {'lr':0.01, 'betas':(0.6, 0.9), 'eps':3e-06,


### PR DESCRIPTION
As the regression has been resolved from PyTorch 1.12.1 and above, the skipped unit tests related to https://github.com/ROCmSoftwarePlatform/apex/issues/82 can be unskipped.

test_adam_option (test_fused_optimizer.TestFusedAdam): due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598
test_multi_device (test_fused_optimizer.TestFusedAdam): due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598
test_float (test_fused_optimizer.TestFusedAdam): due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598
test_bfloat16 (test_fused_optimizer.TestFusedAdam): due to https://github.com/pytorch/pytorch/issues/80809#issuecomment-1175211598


In addition, `test_state_dict (test_checkpointing.TestCheckpointing)` failed because of the following error:
```
Traceback (most recent call last):

  File "/apex/tests/L0/run_amp/test_checkpointing.py", line 252, in test_state_dict

    optimizer.step()

  File "/opt/conda/lib/python3.7/site-packages/torch/optim/optimizer.py", line 109, in wrapper

    return func(*args, **kwargs)

  File "/opt/conda/lib/python3.7/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context

    return func(*args, **kwargs)

  File "/opt/conda/lib/python3.7/site-packages/torch/optim/adam.py", line 171, in step

    capturable=group['capturable'])

  File "/opt/conda/lib/python3.7/site-packages/torch/optim/adam.py", line 226, in adam

    capturable=capturable)

  File "/opt/conda/lib/python3.7/site-packages/torch/optim/adam.py", line 255, in _single_tensor_adam

    assert not step_t.is_cuda, "If capturable=False, state_steps should not be CUDA tensors."

AssertionError: If capturable=False, state_steps should not be CUDA tensors.

```
We can resolve this error by ensuring [torch.optim.Adam](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html) to use `capturable=True` in a CUDA graph.

