### PR TITLE
Fix a bug in fused_dense_cuda on ROCm

### DIFF
--- a/apex/contrib/test/run_rocm_extensions.py
+++ b/apex/contrib/test/run_rocm_extensions.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 
 
-test_dirs = ["groupbn", "layer_norm", "multihead_attn", "transducer", "focal_loss", "index_mul_2d", "."] # "." for test_label_smoothing.py
+test_dirs = ["groupbn", "fused_dense", "layer_norm", "multihead_attn", "transducer", "focal_loss", "index_mul_2d", "."] # "." for test_label_smoothing.py
 ROCM_BLACKLIST = [
     "layer_norm"
 ]

--- a/csrc/fused_dense.cpp
+++ b/csrc/fused_dense.cpp
@@ -62,7 +62,7 @@ std::vector<at::Tensor> linear_bias_backward(at::Tensor input, at::Tensor weight
 
   // create output/workspace tensor
   auto d_weight = at::empty({out_features, in_features}, input.type());
-#if defined(CUBLAS_VERSION) && CUBLAS_VERSION < 11600
+#if (defined(CUBLAS_VERSION) && CUBLAS_VERSION < 11600) || __HIP_PLATFORM_HCC__
   auto d_bias = d_output.view({-1, out_features}).sum(0, false);
 #else                                                                              
   auto d_bias = at::empty({out_features}, input.type());


### PR DESCRIPTION
With Kk's help, we found a bug in fused_dense_cuda on ROCm.  
It failed the unit test of fused_dense on ROCm before this fix. 

Steps to reproduce:
$ cd apex/contrib/test/fused_dense
$ pytest test_fused_dense.py