### PR TITLE
remove HCC references

### DIFF
--- a/apex/contrib/csrc/groupbn/batch_norm.h
+++ b/apex/contrib/csrc/groupbn/batch_norm.h
@@ -124,7 +124,7 @@ class NhwcBatchNorm {
   void processCudnnStatus(const dnnStatus_t& status,
                           const std::string& string = std::string(),
                           bool verbose = VERBOSE_DEFAULT) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
     if (status != DNN_STATUS_SUCCESS)
       LOG(FATAL) << string << " " << miopenGetErrorString(status);
     else if (verbose)
@@ -195,7 +195,7 @@ class NhwcBatchNorm {
                            dnnDataType_t     data_type,
                            int n, int c, int h, int w) {
     dnnStatus_t status = DNN_STATUS_SUCCESS;
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
     status = miopenSet4dTensorDescriptor(descriptor, data_type, n, c, h, w);
 #else
     status = cudnnSetTensor4dDescriptor(descriptor, format, data_type, n, c, h, w);
@@ -205,7 +205,7 @@ class NhwcBatchNorm {
 
   void createTensorDescriptor(dnnTensorDescriptor_t *descriptor) {
     dnnStatus_t status = DNN_STATUS_SUCCESS;
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
     status = miopenCreateTensorDescriptor(descriptor);
 #else
     status = cudnnCreateTensorDescriptor(descriptor);
@@ -215,7 +215,7 @@ class NhwcBatchNorm {
 
   void destroyTensorDescriptor(dnnTensorDescriptor_t descriptor) {
     dnnStatus_t status = DNN_STATUS_SUCCESS;
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
     status = miopenDestroyTensorDescriptor(descriptor);
 #else
     status = cudnnDestroyTensorDescriptor(descriptor);
@@ -279,7 +279,7 @@ class NhwcBatchNorm {
   void _fwdKernelLauncher(cudaStream_t stream, NhwcBatchNormFwdParams params,
                                 dim3 grid_dim, int outer_loops, bool use_relu, const int occupancy, const bool coop) {
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define LAUNCH_FWD_KERNEL(OUTER_LOOPS, USE_RELU, USE_ADD_RELU, COMPILED_FOR_OCCUPANCY, COOP) \
     do { \
         CHECK(SMEM_SIZE_FWD <= MAX_SMEM_WITHOUT_OPT_IN) << "Nhwc batchnorm kernel smem too big."; \
@@ -410,7 +410,7 @@ class NhwcBatchNorm {
 
   void _bwdKernelLauncher(cudaStream_t stream, NhwcBatchNormBwdParams params,
                                 dim3 grid_dim, int outer_loops, bool use_relu, const int occupancy, const bool coop) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define LAUNCH_BWD_KERNEL(OUTER_LOOPS, COMPILED_FOR_OCCUPANCY, COOP) \
     do { \
         CHECK(SMEM_SIZE_BWD <= MAX_SMEM_WITHOUT_OPT_IN) << "Nhwc batchnorm kernel smem too big."; \

--- a/apex/contrib/csrc/groupbn/cuda_utils.h
+++ b/apex/contrib/csrc/groupbn/cuda_utils.h
@@ -1,4 +1,4 @@
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #include <ATen/hip/HIPContext.h>
 #else
 #include <ATen/cuda/CUDAContext.h>
@@ -12,7 +12,7 @@ namespace cuda {
 namespace utils {
 
 static inline int MaxSharedMemoryPerMultiprocessor(int device_id) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
     return getDeviceProperties(device_id)->maxSharedMemoryPerMultiProcessor;
 #else
     return getDeviceProperties(device_id)->sharedMemPerMultiprocessor;

--- a/apex/contrib/csrc/groupbn/dnn.h
+++ b/apex/contrib/csrc/groupbn/dnn.h
@@ -1,7 +1,7 @@
 #ifndef DNN_H
 #define DNN_H
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #include <miopen/miopen.h>
 #define DNN_STATUS_SUCCESS miopenStatusSuccess
 #define DNN_DATA_HALF miopenHalf

--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_cuda.cu
@@ -321,7 +321,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
 
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/encdec_multihead_attn_norm_add_cuda.cu
@@ -377,7 +377,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
   
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/layer_norm.cuh
+++ b/apex/contrib/csrc/multihead_attn/layer_norm.cuh
@@ -211,7 +211,7 @@ template<typename U> U rsqrt(U v) {
 //  return rsqrtf(v);
 //}
 
-#if defined __HIP_PLATFORM_HCC__
+#if defined USE_ROCM
 __device__ float rsqrt(float v) { return rsqrtf(v); }
 #else
 template<> float rsqrt(float v) { return rsqrtf(v); }

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_additive_mask_cuda.cu
@@ -270,7 +270,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
 
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_bias_cuda.cu
@@ -276,7 +276,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
 
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_cuda.cu
@@ -272,7 +272,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
   
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
+++ b/apex/contrib/csrc/multihead_attn/self_multihead_attn_norm_add_cuda.cu
@@ -323,7 +323,7 @@ std::vector<torch::Tensor> bwd_cuda(
   rocblas_int flags = 0;
   
   //TORCH_CUDABLAS_CHECK(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/apex/contrib/csrc/multihead_attn/softmax.cuh
+++ b/apex/contrib/csrc/multihead_attn/softmax.cuh
@@ -18,7 +18,7 @@
 #include <cuda_fp16.h>
 #include <cmath>
  
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define APEX_WARP_SHFL_XOR(mask, value, offset, width) __shfl_xor(value, offset, width)
 #else
 #define APEX_WARP_SHFL_XOR __shfl_xor_sync

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <ctime>
 #include <cassert>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #include "rccl/rccl.h"
 #else
 #include "nccl.h"

--- a/apex/contrib/csrc/transducer/transducer_joint_kernel.cu
+++ b/apex/contrib/csrc/transducer/transducer_joint_kernel.cu
@@ -17,7 +17,7 @@
 
 #include "philox.cuh"
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define SHFL_DOWN(val, laneMask, width) __shfl_down(val, laneMask, width)
 #else
 #define SHFL_DOWN(val, laneMask, width) __shfl_down_sync(0xffffffff, val, laneMask, width)

--- a/apex/contrib/csrc/xentropy/xentropy_kernel.cu
+++ b/apex/contrib/csrc/xentropy/xentropy_kernel.cu
@@ -81,7 +81,7 @@
 
 #define ALIGN_BYTES 16
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define WARP_SIZE 64
 #define SYNCWARP(mask)
 #else

--- a/csrc/fused_dense.cpp
+++ b/csrc/fused_dense.cpp
@@ -62,7 +62,7 @@ std::vector<at::Tensor> linear_bias_backward(at::Tensor input, at::Tensor weight
 
   // create output/workspace tensor
   auto d_weight = at::empty({out_features, in_features}, input.type());
-#if (defined(CUBLAS_VERSION) && CUBLAS_VERSION < 11600) || __HIP_PLATFORM_HCC__
+#if (defined(CUBLAS_VERSION) && CUBLAS_VERSION < 11600) || USE_ROCM
   auto d_bias = d_output.view({-1, out_features}).sum(0, false);
 #else                                                                              
   auto d_bias = at::empty({out_features}, input.type());

--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -30,7 +30,7 @@ cublasStatus_t gemm_bias(
     const float* beta,
     double* C,
     int ldc) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,
@@ -96,7 +96,7 @@ cublasStatus_t gemm_bias(
     const float* beta,
     float* C,
     int ldc) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,
@@ -163,7 +163,7 @@ cublasStatus_t gemm_bias(
     const float* beta,
     at::Half* C,
     int ldc) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -306,7 +306,7 @@ void cuWelfordMuSigma2(
 template<typename U> U rsqrt(U v) {
   return U(1) / sqrt(v);
 }
-#if defined __HIP_PLATFORM_HCC__
+#if defined USE_ROCM
 __device__ float rsqrt(float v) {
   return rsqrtf(v);
 }
@@ -709,7 +709,7 @@ void cuComputeGradInput(
     const int numx = blockDim.x * blockDim.y;
     const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
     if (gamma != NULL) {
-      #ifndef __HIP_PLATFORM_HCC__
+      #ifndef USE_ROCM
       int l = 4*thrx;
       for (;  l+3 < n2;  l+=4*numx) {           
         for (int k = 0;  k < 4;  ++k) {
@@ -750,7 +750,7 @@ void cuComputeGradInput(
       }
       #endif
     } else {
-      #ifndef __HIP_PLATFORM_HCC__
+      #ifndef USE_ROCM
       int l = 4*thrx;
       for (;  l+3 < n2;  l+=4*numx) {
         for (int k = 0;  k < 4;  ++k) {
@@ -888,7 +888,7 @@ void HostApplyLayerNorm(
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     const int warp_size = at::cuda::warp_size();
     dim3 threads(warp_size ,4, 1);  // MI100 wavefront/warp = 64
-    #ifdef __HIP_PLATFORM_HCC__
+    #ifdef USE_ROCM
     // Optimization for ROCm MI100
     threads.y = 1;
     #endif
@@ -919,7 +919,7 @@ void HostApplyRMSNorm(
     const uint64_t maxGridY = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
     const dim3 blocks(1, std::min((uint64_t)n1, maxGridY), 1);
     dim3 threads(warp_size,4,1);
-    #ifdef __HIP_PLATFORM_HCC__
+    #ifdef USE_ROCM
     // Optimization for ROCm MI100
     threads.y = 2;
     #endif
@@ -1059,7 +1059,7 @@ void HostLayerNormGradient(
     const uint64_t maxGridY = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
     const dim3 blocks1(1, std::min((uint64_t)n1, maxGridY), 1);
     dim3 threads1(warp_size,4,1);  // MI100 wavefront/warp = 64
-    #ifdef __HIP_PLATFORM_HCC__
+    #ifdef USE_ROCM
     // Optimization for ROCm MI100
     threads1.y = 2;
     #endif

--- a/csrc/mlp_cuda.cu
+++ b/csrc/mlp_cuda.cu
@@ -75,7 +75,7 @@ cublasStatus_t mlp_gemm(
     double* C,
     int ldc,
     int flag) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,
@@ -142,7 +142,7 @@ cublasStatus_t mlp_gemm(
     float* C,
     int ldc,
     int flag) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,
@@ -210,7 +210,7 @@ cublasStatus_t mlp_gemm(
     at::Half* C,
     int ldc,
     int flag) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
   return rocblas_gemm_ex(
       handle,
       transa,
@@ -1506,7 +1506,7 @@ int mlp_bp(
   cudaStream_t stream;
   cublasGetStream(handle, &stream);
   int flag = 0;
-  #ifdef __HIP_PLATFORM_HCC__
+  #ifdef USE_ROCM
     #define PYTORCH_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
     #define USE_GEMM_FLAGS_FP16_ALT_IMPL (PYTORCH_ROCBLAS_VERSION_DECIMAL >= 242)
     #if USE_GEMM_FLAGS_FP16_ALT_IMPL

--- a/csrc/multi_tensor_apply.cuh
+++ b/csrc/multi_tensor_apply.cuh
@@ -27,7 +27,7 @@ template<int n> struct TensorListMetadata
 
 
 template<typename T, typename U, typename... ArgTypes>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(1024)
 #endif
 __global__ void multi_tensor_apply_kernel(

--- a/csrc/multi_tensor_apply_base.cuh
+++ b/csrc/multi_tensor_apply_base.cuh
@@ -27,7 +27,7 @@ template<int n> struct TensorListMetadata
 
 
 template<typename T, typename U, typename... ArgTypes>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(1024)
 #endif
 __global__ void multi_tensor_apply_kernel(

--- a/csrc/multi_tensor_l2norm_kernel.cu
+++ b/csrc/multi_tensor_l2norm_kernel.cu
@@ -196,7 +196,7 @@ struct MaxNormFunctor
 
 
 __global__ void
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(1024)
 #endif
 cleanup(
@@ -237,7 +237,7 @@ cleanup(
 }
 
 __global__ void
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(1024)
 #endif
 cleanup_v2(

--- a/csrc/type_shim.h
+++ b/csrc/type_shim.h
@@ -415,7 +415,7 @@ __device__ __forceinline__ T reduce_block_into_lanes
 
     #pragma unroll
     for(int i = warpSize / 2; i >= lanes; i >>= 1) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
       final = final + __shfl_down(final, i);
 #else
       final = final + __shfl_down_sync(0xffffffff, final, i);
@@ -471,7 +471,7 @@ __device__ __forceinline__ T reduce_block_into_lanes_max_op
 
     #pragma unroll
     for(int i = 16; i >= lanes; i >>= 1) {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
       final = fmaxf(fabsf(final), fabsf(__shfl_down(final, i)));
 #else
       final = fmaxf(fabsf(final), fabsf(__shfl_down_sync(0xffffffff, final, i)));

--- a/csrc/welford.cu
+++ b/csrc/welford.cu
@@ -11,7 +11,7 @@
 #include "type_shim.h"
 #include "compat.h"
 
-#if defined __HIP_PLATFORM_HCC__
+#if defined USE_ROCM
 #define SHFL_DOWN(mask,val,i) __shfl_down(val, i)
 #else
 #define SHFL_DOWN __shfl_down_sync
@@ -44,7 +44,7 @@ __host__ __forceinline__ int h_last_pow2(unsigned int n) {
     return n - (n >> 1);
 }
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 #define WARP_SIZE 64
 #else
 #define WARP_SIZE 32
@@ -266,7 +266,7 @@ __device__ __forceinline__ void merge_block_vertical(T& sum_dy,
 
 // welford kernel calculating mean/biased_variance/unbiased_variance
 template <typename scalar_t, typename accscalar_t, typename outscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void welford_kernel(
@@ -308,7 +308,7 @@ __global__ void welford_kernel(
 
 // elementwise BN kernel
 template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void batchnorm_forward_kernel(
@@ -338,7 +338,7 @@ __global__ void batchnorm_forward_kernel(
 // Breaking the grad_input to two step to support sync BN, which requires all
 // reduce of the intermediate results across processes.
 template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void reduce_bn_kernel(
@@ -405,7 +405,7 @@ __global__ void reduce_bn_kernel(
 
 // elementwise backward BN kernel
 template <typename scalar_t, typename accscalar_t, typename layerscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void batchnorm_backward_kernel(
@@ -447,7 +447,7 @@ template
     typename accscalar_t,
     typename outscalar_t,
     int PARALLEL_LOADS>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void
@@ -591,7 +591,7 @@ welford_kernel_c_last(
 // parallel welford kernel to further reduce mean / biased_var
 // into mean / unbiased_var / inv_std across multiple processes.
 template <typename scalar_t>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void welford_kernel_parallel(
@@ -627,7 +627,7 @@ template <
     typename accscalar_t,
     typename layerscalar_t,
     int PARALLEL_LOADS>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void batchnorm_forward_c_last_kernel(
@@ -680,7 +680,7 @@ template <
     typename accscalar_t,
     typename layerscalar_t,
     int PARALLEL_LOADS>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void relu_backward_c_last_kernel(
@@ -733,7 +733,7 @@ template
     typename accscalar_t,
     typename layerscalar_t,
     int PARALLEL_LOADS>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void reduce_bn_c_last_kernel(
@@ -889,7 +889,7 @@ template <
     typename accscalar_t,
     typename layerscalar_t,
     int PARALLEL_LOADS>
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef USE_ROCM
 __launch_bounds__(MAX_BLOCK_SIZE)
 #endif
 __global__ void batchnorm_backward_c_last_kernel(


### PR DESCRIPTION
rename `__HIP_PLATFORM_HCC__` to `USE_ROCM`. We were using the former to mean USE_ROCM as it is used in pytorch. The `-DUSE_ROCM` comes from using the pytorch CUDAExtension class.