### PR TITLE
Batchnorm support

### DIFF
--- a/tests/distributed/run_rocm_distributed.sh
+++ b/tests/distributed/run_rocm_distributed.sh
@@ -1,12 +1,15 @@
-#!/bin/bash
+#!/bin/bash -x
 set -e
 
 # To run the test on 2 gpus
 export WORLD_SIZE=2
 
+torchrun=`dirname \`which python\``/torchrun
+
 # Test with opt_level="O2"
 echo "running opt_level O2"
-python -m torch.distributed.launch --nproc_per_node=2 amp_master_params/amp_master_params.py --opt_level "O2"
+# python -m torch.distributed.launch --nproc_per_node=2 amp_master_params/amp_master_params.py --opt_level "O2"
+python $torchrun --nproc_per_node=2 amp_master_params/amp_master_params.py --opt_level "O2"
 python amp_master_params/compare.py
 
 # delete the model files

--- a/tests/distributed/synced_batchnorm/unit_test.sh
+++ b/tests/distributed/synced_batchnorm/unit_test.sh
@@ -1,8 +1,8 @@
 python python_single_gpu_unit_test.py || exit 1
 python single_gpu_unit_test.py || exit 1
 python test_batchnorm1d.py || exit 1
-python -m torch.distributed.launch --nproc_per_node=2 two_gpu_unit_test.py || exit 1
-python -m torch.distributed.launch --nproc_per_node=2 two_gpu_unit_test.py --fp16 || exit 1
-python -m torch.distributed.launch --nproc_per_node=2 two_gpu_test_different_batch_size.py --apex || exit 1
+torchrun --nnodes 1 --nproc-per-node 2  two_gpu_unit_test.py || exit 1
+torchrun --nnodes 1 --nproc-per-node 2  two_gpu_unit_test.py --fp16  || exit 1
+torchrun --nnodes 1 --nproc-per-node 2  two_gpu_test_different_batch_size.py --apex || exit 1
 #beware, you need a system with at least 4 gpus to test group_size<world_size
-#python -m torch.distributed.launch --nproc_per_node=4 test_groups.py --group_size=2
+# torchrun --nnodes 1 --nproc-per-node 4 test_groups.py --group_size=2 


### PR DESCRIPTION
Fixes to Sync batchnorm test scripts. 

Test result:
torchrun --nnodes 1 --nproc-per-node 2  two_gpu_test_different_batch_size.py --apex
[2024-01-18 19:22:08,932] torch.distributed.run: [WARNING]
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
====SBN two gpu with different batches test passed

torchrun --nnodes 1 --nproc-per-node 2  two_gpu_unit_test.py
[2024-01-18 19:43:50,447] torch.distributed.run: [WARNING]
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
--- count :  --- count :  tensor([25600, 25600], device='cuda:1', dtype=torch.int32)
tensor([25600, 25600], device='cuda:0', dtype=torch.int32)
====SBN two gpu passed tests
====SBN two gpu passed tests
