### PR TITLE
Reset torch default device to cpu after running the amp unit tests.

### DIFF
--- a/tests/L0/run_amp/test_add_param_group.py
+++ b/tests/L0/run_amp/test_add_param_group.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from torch.nn import Parameter
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 class MyModel(torch.nn.Module):
     def __init__(self, unique, dtype=torch.float16):
@@ -37,7 +37,7 @@ class TestAddParamGroup(unittest.TestCase):
         common_init(self)
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     def zero_grad(self, models, optimizer, how_to_zero):
         if how_to_zero == "none":

--- a/tests/L0/run_amp/test_basic_casts.py
+++ b/tests/L0/run_amp/test_basic_casts.py
@@ -9,7 +9,7 @@ from torch import nn
 import torch.nn.functional as F
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_BFLOAT16, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_BFLOAT16, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 from apex.testing.common_utils import skipIfRocm
 
@@ -73,6 +73,7 @@ class TestBasicCastsHalf(_TestBasicCasts):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
     
     def test_linear_is_half(self):
         self._test_linear(ALWAYS_HALF)
@@ -102,6 +103,7 @@ class TestBasicCastsBFloat16(_TestBasicCasts):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     @skipIfRocm
     def test_linear_is_bfloat16(self):
@@ -133,6 +135,7 @@ class TestBannedMethods(unittest.TestCase):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def bce_common(self, assertion, dtype=torch.half):
         shape = (self.b, self.h)
@@ -202,6 +205,7 @@ class TestTensorCastsHalf(_TestTensorCasts):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def test_matmul_method_is_half(self):
         self._test_matmul_method(ALWAYS_HALF)
@@ -230,6 +234,7 @@ class TestTensorCastsBFloat16(_TestTensorCasts):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     @skipIfRocm
     def test_matmul_method_is_bfloat16(self):

--- a/tests/L0/run_amp/test_cache.py
+++ b/tests/L0/run_amp/test_cache.py
@@ -10,7 +10,7 @@ from torch import nn
 import torch.nn.functional as F
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 def get_reference_grad(i, w, ops):
     # Creating new tensors ensures, among other things, that the new tensors are not in the cache.
@@ -65,7 +65,7 @@ class TestCache(unittest.TestCase):
         common_init(self)
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     def train_eval_train_test(self, module, t, opt_level):
         model = module(t).cuda()

--- a/tests/L0/run_amp/test_larc.py
+++ b/tests/L0/run_amp/test_larc.py
@@ -6,7 +6,7 @@ from torch.nn import Parameter
 
 from apex import amp
 from apex.parallel.LARC import LARC
-from utils import common_init
+from utils import common_init, common_reset
 from apex.amp import _amp_state
 
 
@@ -27,7 +27,7 @@ class TestLARC(unittest.TestCase):
         common_init(self)
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     def test_larc_mixed_precision(self):
         for opt_level in ["O0", "O1", "O2", "O3"]:

--- a/tests/L0/run_amp/test_multi_tensor_axpby.py
+++ b/tests/L0/run_amp/test_multi_tensor_axpby.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from math import floor
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 try:
   import amp_C
@@ -39,7 +39,7 @@ class TestMultiTensorAxpby(unittest.TestCase):
         self.ref = torch.full((1,), 136.0, device="cuda", dtype=torch.float32)
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     # The tensor creation here is written for convenience, not speed.
     def axpby(self, sizea, sizeb, applier, repeat_tensors,

--- a/tests/L0/run_amp/test_multi_tensor_l2norm.py
+++ b/tests/L0/run_amp/test_multi_tensor_l2norm.py
@@ -9,7 +9,7 @@ from torch import nn
 import torch.nn.functional as F
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 try:
   import amp_C
@@ -29,7 +29,7 @@ class TestMultiTensorL2Norm(unittest.TestCase):
         self.overflow_buf = torch.tensor(1, dtype=torch.int, device='cuda').zero_()
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     # The tensor creation here is written for convenience, not speed.
     def l2norm(self, sizea, sizeb, applier, repeat_tensors, in_type, per_tensor):

--- a/tests/L0/run_amp/test_multi_tensor_scale.py
+++ b/tests/L0/run_amp/test_multi_tensor_scale.py
@@ -9,7 +9,7 @@ from torch import nn
 import torch.nn.functional as F
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 try:
   import amp_C
@@ -30,7 +30,7 @@ class TestMultiTensorScale(unittest.TestCase):
         self.ref = torch.cuda.FloatTensor([1.0])
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     # The tensor creation here is written for convenience, not speed.
     def downscale(self, sizea, sizeb, applier, repeat_tensors, in_type, out_type, inplace=False):

--- a/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
+++ b/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from torch.nn import Parameter
 
 from utils import common_init, HALF, FLOAT,\
-    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT, common_reset
 
 class MyModel(torch.nn.Module):
     def __init__(self, unique):
@@ -40,7 +40,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
         common_init(self)
 
     def tearDown(self):
-        pass
+        common_reset(self)
 
     def test_2models2losses1optimizer(self):
         model0 = MyModel(1)

--- a/tests/L0/run_amp/test_promotion.py
+++ b/tests/L0/run_amp/test_promotion.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-from utils import common_init, HALF, FLOAT, DTYPES, DTYPES2, MATCH_INPUT
+from utils import common_init, HALF, FLOAT, DTYPES, DTYPES2, MATCH_INPUT, common_reset
 
 class _TestPromotion(unittest.TestCase):
     def run_binary_promote_test(self, fns, input_shape, lp_type, x_inplace=False):
@@ -64,6 +64,7 @@ class TestPromotionHalf(_TestPromotion):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def test_atan2_matches_widest(self):
         fns = [lambda x, y : torch.atan2(x, y),
@@ -92,6 +93,7 @@ class TestPromotionBFloat16(_TestPromotion):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def test_mul_matches_widest(self):
         fns = [lambda x, y : torch.mul(x, y),

--- a/tests/L0/run_amp/test_rnn.py
+++ b/tests/L0/run_amp/test_rnn.py
@@ -5,7 +5,7 @@ import random
 import torch
 from torch import nn
 
-from utils import common_init, HALF
+from utils import common_init, HALF, common_reset
 from apex.testing.common_utils import skipIfRocm
 
 class TestRnnCells(unittest.TestCase):
@@ -15,6 +15,7 @@ class TestRnnCells(unittest.TestCase):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def run_cell_test(self, cell, state_tuple=False):
         shape = (self.b, self.h)
@@ -59,6 +60,7 @@ class TestRnns(unittest.TestCase):
 
     def tearDown(self):
         self.handle._deactivate()
+        common_reset(self)
 
     def run_rnn_test(self, rnn, layers, bidir, state_tuple=False):
         for typ in [torch.float, torch.half]:

--- a/tests/L0/run_amp/utils.py
+++ b/tests/L0/run_amp/utils.py
@@ -26,3 +26,7 @@ def common_init(test_case):
     test_case.t = 10
     torch.set_default_device('cuda')
     torch.set_default_dtype(torch.float)
+
+
+def common_reset(test_case):
+    torch.set_default_device('cpu')

--- a/tests/L0/run_transformer/test_batch_sampler.py
+++ b/tests/L0/run_transformer/test_batch_sampler.py
@@ -7,9 +7,6 @@ from torch.utils.data import RandomSampler
 from torch.utils.data import BatchSampler
 from torch.utils.data import DataLoader
 
-#reset the default device to cpu so that the generator, as run_amp tests set its to cuda
-torch.set_default_device('cpu')
-
 from apex.transformer.pipeline_parallel.utils import _split_batch_into_microbatch as split_batch_into_microbatch
 
 


### PR DESCRIPTION
Fix for : https://ontrack-internal.amd.com/browse/SWDEV-523467 

