### PR TITLE
change epilogue parameter for hipblaslt matmul in cuda kernel for fused dense gelu dense

### DIFF
--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -244,7 +244,7 @@ int gemm_lt(
     }
     else
     {
-      epilogue = HIPBLASLT_EPILOGUE_GELU_AUX_BIAS;
+      epilogue = HIPBLASLT_EPILOGUE_GELU_BIAS;
     }
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(matmulDesc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, 
                                                           &d_bias, sizeof(d_bias)));


### PR DESCRIPTION
change epilogue parameter for hipblaslt matmul in cuda kernel for fused dense gelu dense

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-534531