### PR TITLE
update the param_id calculation so that it works on both CPX and SPX modes

### DIFF
--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -212,7 +212,8 @@ class PipelineParallelForwardBackwardTestBase:
                         params = list(model_module.parameters())
                         rank = params[0].get_device()
                         offset = pipeline_model_parallel_world_size
-                        param_id = rank // data_parallel_size + vm_id * offset
+                        param_id = parallel_state.get_pipeline_model_parallel_rank() + vm_id * pipeline_model_parallel_world_size
+                        # param_id = rank // data_parallel_size + vm_id * offset
                         target_params = target_model[param_id]
 
                         self.assertEqual(params[0].cpu(), target_params[0])


### PR DESCRIPTION
update the param_id calculation so that it works on both CPX and SPX modes

## Motivation

These 4 tests failed in MI308 machine because they had virtual GPUs

```
test_learning_pipelining_without_interleaving 

test_learning_pipelining_with_interleaving 

test_learning_async_pipelining_without_interleaving 

test_learning_async_pipelining_with_interleaving 
```

## Technical Details

On CPX, local device ids are not laid out in contiguous DP groups. So the computed param_id doesn’t match the stage that initialized the module

So the solution is to use 

` param_id = parallel_state.get_pipeline_model_parallel_rank() + vm_id * pipeline_model_parallel_world_size
` 
## Test Plan

The indivigual tests were tested with this 

`python3 tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py -k test_learning_async_pipelining_with_interleaving 

`python3 tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py -k test_learning_async_pipelining_without_interleaving 

`python3 tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py -k test_learning_pipelining_with_interleaving 

`python3 tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py -k test_learning_pipelining_without_interleaving 
`
And all the test were tested with this.

`python3 run_test.py --include run_transformer`

## Test Result

Tested with this docker 
registry-sc-harbor.amd.com/framework/compute-rocm-rel-7.0:24_ubuntu22.04_py3.10_pytorch_lw_rocm7.0_internal_testing_d36b5258

Attached log file 
[Run_Transformer_test.txt](https://github.com/user-attachments/files/21719138/Run_Transformer_test.txt)


Fixes : https://ontrack-internal.amd.com/browse/SWDEV-548434 