### PR TITLE
[release/1.9.0] setup.py reads BUILD_VERSION env variable, along with version.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,8 @@ def get_apex_version():
             apex_version = f.read().strip()
     else:
         raise RuntimeError("version.txt file is missing")
+    if os.getenv("BUILD_VERSION"):
+        apex_version = os.getenv("BUILD_VERSION")
     if os.getenv("DESIRED_CUDA"):
         apex_version += "+" + os.getenv("DESIRED_CUDA")
         if os.getenv("APEX_COMMIT"):


### PR DESCRIPTION
## Motivation

setup.py reads BUILD_VERSION env variable, along with version.txt, so that BUILD_VERSION is used instead of version.txt when creating a wheel

## Technical Details

Similar to other existing repos e.g. torchaudio - https://github.com/ROCm/audio/blob/main/setup.py#L27

```
def _get_version(sha):
    with open(ROOT_DIR / "version.txt", "r") as f:
        version = f.read().strip()
    if os.getenv("BUILD_VERSION"):
        version = os.getenv("BUILD_VERSION")
```

## Test Plan

Build apex wheel with explicit BUILD_VERSION.

`BUILD_VERSION=1.9.0+rocmsdk20251121 python -m build --wheel --no-isolation -C--build-option=--cpp_ext -C--build-option=--cuda_ext`

## Test Result

This builds apex wheel -` apex-1.9.0+rocmsdk20251121-py3-none-any.whl`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
