### PR TITLE
[Release/1.9.0] Fix bare metal version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_rocm_bare_metal_version(rocm_dir):
     release_idx = output.index("version:") + 1
     release = output[release_idx].split(".")
     bare_metal_major = release[0]
-    bare_metal_minor = release[1][0]
+    bare_metal_minor = release[1]
     return raw_output, bare_metal_major, bare_metal_minor
 
 def check_cuda_torch_binary_vs_bare_metal(cuda_dir):
@@ -102,9 +102,9 @@ def check_rocm_torch_binary_vs_bare_metal(rocm_dir):
 
     if (bare_metal_major != torch_binary_major) or (bare_metal_minor != torch_binary_minor):
         raise RuntimeError(
-            "Cuda extensions are being compiled with a version of Cuda that does "
+            "ROCm extensions are being compiled with a version of ROCm that does "
             "not match the version used to compile Pytorch binaries.  "
-            "Pytorch binaries were compiled with Cuda {}.\n".format(torch.version.cuda)
+            "Pytorch binaries were compiled with ROCm {}.\n".format(torch.version.hip)
             + "In some cases, a minor-version mismatch will not cause later errors:  "
             "https://github.com/NVIDIA/apex/pull/323#discussion_r287021798.  "
             "You can try commenting out this check (at your own risk)."


### PR DESCRIPTION
## Motivation

Fix the apex wheel creation on TheRock

## Technical Details

The previous code worked for rocm versions with one digit in the minor version e.g. 7.2 but not or 2 digit versions e.g. 7.12

## Test Plan

Run the code to build apex wheel locally for TheRock for not working (rocm7.12) and previously working condition (rocm7.11). 

```
./external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git release/2.9 
./external-builds/pytorch/pytorch_apex_repo.py checkout --repo-hashtag fix_cuda_mismatch 
./external-builds/pytorch/build_prod_wheels.py build   --install-rocm   --pip-cache-dir /tmp/pipcache --index-url "https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/"    --clean --output-dir dist --rocm-sdk-version ==7.12.0a20260213 --version-suffix +rocm7.12.0a20260213 (previously not working)
./external-builds/pytorch/build_prod_wheels.py build  --install-rocm  --pip-cache-dir /tmp/pipcache    --index-url "https://rocm.devreleases.amd.com/v2/gfx94X-dcgpu/"  --clean  --output-dir dist --rocm-sdk-version ==7.11.0a20251124 --version-suffix +rocm7.11.0a20251124 (previously working)
```

Run apex installation in rocm7.3 docker - registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16972_ubuntu24.04_py3.12_pytorch_release-2.9_7e1940d4
`pip install -v --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
`

## Test Result

Creates apex wheel successfully for TheRock.

- apex-1.9.0+rocm7.12.0a20260213-cp312-cp312-linux_x86_64.whl
- apex-1.9.0+rocm7.11.0a20251124-cp312-cp312-linux_x86_64.whl

Successfully installed apex in rocm7.3.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
