### PR TITLE
Add new apex module to jit load system (#294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,97 @@ APEX_BUILD_FUSED_DENSE​=1 pip install . --no-build-isolation
 ```
 This will pre-build and install FUSED_DENSE​ module and rest of the modules are installed to be JIT built and loaded at runtime. 
 
-
-
 Aiter backend can be built and used for fused rope. To install aiter:
 ```
 make aiter
 ```
 
 To use aiter in fused rope, you can use the flag ```USE_ROCM_AITER_ROPE_BACKEND=1```.
+
+### To add a new module into jit loader
+
+What is JIT (just-in-time) load? Just-in-time load helps to build the specific modules that are used without needing to build all modules during installation time. This helps to significantly reduce installation time. Without JIT load, it would take roughtly 30 minutes to install apex. With JIT load, it takes less than 1 minute to install apex. 
+
+A python script is provided to ease the process of adding a new module to JIT load. 
+For this, the user must create C++/CUDA source code for a new apex module in either csrc or apex/contrib/csrc folder. 
+This script helps to create a builder and a loader for the apex module.
+The builder creates the .so file for the apex module (during installation or jit load time) and the loader loads the .so file when the module is imported.
+
+To run the script:
+
+```
+python scripts/jit_module.py <apex_module_name>
+``` 
+
+The user should provide the name used to import the module i.e. import fused_bias_swiglu.
+If the user does not provide the module name, the script will ask for the module name
+```
+What is the name of the module?
+``` 
+
+The script is interactive and asks two questions 
+1. Is this a CUDA module? (Y/n)
+2. Enter the sources (comma separated) Press Enter to skip 
+
+If the user answers yes to cuda module, it builds with CUDAOpBuilder otherwise it builds as a cpu operation with CPUOpBuilder. The default is cuda operation.
+The user must mention the list of .cpp, .h, .cu files used to compile the module as a comma separated list.
+This argument is used to define the return value of sources() method in the builder module.
+This will be used to also find the list of directories (include_paths() method) i.e. -I flag in g++ compiler. 
+The user can decide to skip the list of sources and add it manually to the builder file created by the script. 
+
+e.g.  
+```
+python scripts/jit_module.py fused_bias_swiglu
+1. Is this a CUDA module? (Y/n) y
+2. Enter the sources (comma separated) Press Enter to skip csrc/megatron/fused_bias_swiglu.cpp,csrc/megatron/fused_bias_swiglu_cuda.cu
+```
+
+**Directory structure (fused_bias_swiglu example):**
+
+The above example creates a builder - [op_builder/fused_bias_swiglu.py](op_builder/fused_bias_swiglu.py) and a loader - [compatibility/fused_bias_swiglu.py](compatibility/fused_bias_swiglu.py).
+
+```
+apex/                                    # repo root
+├── csrc/                                # C++/CUDA source (or apex/contrib/csrc)
+│   └── megatron/
+│       ├── fused_bias_swiglu.cpp        # PyBind11 module defs, declarations
+│       └── fused_bias_swiglu_cuda.cu    # CUDA kernels / implementation
+├── op_builder/                          # Builder: compiles sources → .so
+│   └── fused_bias_swiglu.py             # FusedBiasSwiGLUBuilder (NAME = "fused_bias_swiglu", sources(), etc.)
+├── compatibility/                       # Loader: JIT-loads .so when module is imported
+│   └── fused_bias_swiglu.py             # _FusedBiasSwiGLUModule (loads via apex.op_builder.FusedBiasSwiGLUBuilder)
+└── apex/                                # Python package
+    └── fused_bias_swiglu/               # User-facing API (import apex.fused_bias_swiglu)
+        ├── __init__.py
+        └── fused_bias_swiglu.py         # imports fused_bias_swiglu, wraps forward/backward, etc.
+```
+
+
+The user must not edit the loader code. 
+
+The script creates an initial builder code and the users can edit the methods in the module.
+
+The builder module is created in op_builder folder and must override either CPUOpBuilder or CUDAOpBuilder class and define the following attributes and methods:
+
+| Attribute | Purpose |
+|-----------|-----------|
+| BUILD_VAR | The environment variable to indicate prebuilding the module when installing apex e.g. APEX_BUILD_FUSED_BIAS_SWIGLU for fused_bias_swiglu|
+| INCLUDE_FLAG | Either APEX_BUILD_CUDA_OPS or APEX_BUILD_CPU_OPS to indicate whether the module will be built for gpu or cpu |
+| NAME | name of module e.g. fused_bias_swiglu |
+
+| Method | Purpose | Necessary to override | 
+|-----------|-----------|-----------|
+| absolute_name | return the namespace where the module will be installed | Yes |
+| sources | list of C++/CUDA source files for the module | Yes |
+| include_paths | list of folders where the included headers mentioned in the source files are placed | No |
+| cxx_args | return a list of extra compiler flags for the C++ compiler when building C++ sources (e.g. optimization level, preprocessor macros) | No |
+| nvcc_args | return a list of extra compiler flags for nvcc when building CUDA sources (e.g. -O3, architecture flags, preprocessor macros) | No |
+| is_compatible | can this module be installed and loaded considering the environment e.g.minimum torch version supported | No |
+| libraries_args  | list of libraries to compile against e.g. MIOpen | No |
+
+
+
+
 
 ### To create a wheel and then install apex using the wheel, use the following command in apex folder:
 ```

--- a/scripts/jit_module.py
+++ b/scripts/jit_module.py
@@ -1,0 +1,242 @@
+"""
+Script to test JIT module for Apex.
+"""
+
+import sys
+import os
+
+class JitModule:
+
+    def __init__(self):
+        self.op_builder_folder = "op_builder"
+        self.compatability_folder = "compatibility"
+
+    def get_module_name(self, builder_file_name):
+        #open builder file and read the NAME attribute  
+        with open(os.path.join(self.op_builder_folder, f"{builder_file_name}.py"), "r") as f:
+            contents = f.read()
+        for line in contents.split("\n"):
+            if "NAME = " in line:
+                return line.split("NAME = ")[1].strip()[1:-1]
+        return None
+
+
+    def create_loader_class_name(self, module_name):
+        parts = module_name.split("_")
+        new_name = ""
+        for part in parts:
+            new_name += part.capitalize()
+        return f"_{new_name}Module"
+
+
+    def create_builder_class_name(self, module_name):
+        parts = module_name.split("_")
+        new_name = ""
+        for part in parts:
+            new_name += part.capitalize()
+        return f"{new_name}Builder"
+
+    
+    def create_build_var(self, module_name):
+        return f"APEX_BUILD_{module_name.upper()}"
+
+
+    def check_if_builder_module_exists(self, module_name):
+        if os.path.exists(os.path.join(self.op_builder_folder, f"{module_name}.py")):
+            return True
+        else:
+            return False
+
+    def check_if_loader_module_exists(self, module_name):
+        if os.path.exists(os.path.join(self.compatability_folder, f"{module_name}.py")):
+            return True
+        else:
+            return False
+
+
+    def findBuilderClassName(self, builder_name):
+        #read file contents of op_builder/builder_name.py
+        with open(os.path.join(self.op_builder_folder, f"{builder_name}.py"), "r") as f:
+            contents = f.read()
+        #find the class name that inherits from CPUOpBuilder or CUDAOpBuilder
+        for line in contents.split("\n"):
+            if "class" in line:
+                return line.split("class")[1].split("(")[0].strip()
+        return None
+
+
+    def create_loader(self, builder_name):
+        module_name = self.get_module_name(builder_name) or builder_name
+        #check if a loader module in compatability folder
+        is_loader_exists = self.check_if_loader_module_exists(module_name)
+        if is_loader_exists:
+            print(f"Loader module {module_name} exists")
+            return
+
+        #create loader class name to use in loader module
+        loader_class_name = self.create_loader_class_name(module_name)
+
+        #find builder class name to use in the loader
+        builder_class_name = self.findBuilderClassName(builder_name)
+
+        #create a loader module in compatability folder
+        with open(os.path.join(self.compatability_folder, f"{module_name}.py"), "w") as f:
+            f.write(f"import sys\n")
+            f.write(f"import importlib\n")
+            f.write(f"\n")
+            f.write(f"class {loader_class_name}:\n")
+            f.write(f"    def __init__(self):\n")
+            f.write(f"        self._loaded_module = None\n")
+            f.write(f"        self._loading = False\n")
+            f.write(f"\n")
+            f.write(f"    def _load_module(self):\n")
+            f.write(f"        if self._loaded_module is None and not self._loading:\n")
+            f.write(f"            self._loading = True\n")
+            f.write(f"            try:\n")
+            f.write(f"                apex_op_builder = importlib.import_module('apex.op_builder')\n")
+            f.write(f"                builder = getattr(apex_op_builder, '{builder_class_name}')\n")
+            f.write(f"                self._loaded_module = builder().load()\n")
+            f.write(f"            except Exception as e:\n")
+            f.write(f"                self._loading = False\n")
+            f.write(f"                raise ImportError('Failed to load " + builder_name + " :' + str(e))\n")
+            f.write(f"            finally:\n")
+            f.write(f"                self._loading = False\n")
+            f.write(f"        return self._loaded_module\n")
+            f.write(f"\n")
+            f.write(f"    def __getattr__(self, name):\n")
+            f.write(f"        if name.startswith('_'):\n")
+            f.write(f"            raise AttributeError(f'module {module_name} has no attribute ' + name)\n")
+            f.write(f"        return getattr(self._load_module(), name)\n") #dynamic loading of the module
+            f.write(f"\n")
+            f.write(f"    def __dir__(self):\n")
+            f.write(f"        try:\n")
+            f.write(f"            return dir(self._load_module())\n")
+            f.write(f"        except:\n")
+            f.write(f"            return []\n")
+            f.write(f"\n")
+            f.write(f"    def __repr__(self):\n")
+            f.write(f"        return '<module {module_name}>'\n")
+            f.write(f"\n")
+            f.write(f"sys.modules[__name__] = {loader_class_name}()\n")
+
+        print(f"Loader module {module_name} created")
+
+
+    def create_builder(self, module_name):
+        #Interactively prompt for builder details and create the builder module.
+        if_cuda_module = input("Is this a CUDA module? (Y/n) ").strip() or "y"
+        sources = input("Enter the sources (comma separated). Press Enter to skip ").strip()
+
+
+        if if_cuda_module == "y":
+            class_name = "CUDAOpBuilder"
+            include_flag = "APEX_BUILD_CUDA_OPS"
+        else:
+            class_name = "CPUOpBuilder"
+            include_flag = "APEX_BUILD_CPU_OPS"
+
+        builder_class_name = self.create_builder_class_name(module_name)
+        build_var = self.create_build_var(module_name)
+        
+        if len(sources) == 0:
+            sources_list = []
+            sources_list_string = "[]"
+        else:
+            sources_list = sources.split(",")
+            sources_list_string = "[" + ",".join(["'" + source.strip() + "'" for source in sources_list]) + "]"
+        print(f"sources_list_string: {sources_list_string}")
+
+        include_paths = []
+        for source in sources_list:
+            if "csrc" in source and "csrc" not in include_paths:
+                include_paths.append("csrc")
+            elif "contrib/csrc" in source and "contrib/csrc" not in include_paths:
+                include_paths.append("contrib/csrc")
+        include_paths_string = "[" + ",".join(["'" + path.strip() + "'" for path in include_paths]) + "]"
+
+        with open(os.path.join(self.op_builder_folder, f"{module_name}.py"), "w") as f:
+            if if_cuda_module == "y":
+                f.write(f"from .builder import CUDAOpBuilder\n")
+            else:
+                f.write(f"from .builder import CPUOpBuilder\n")
+            f.write(f"\n")
+            f.write(f"class {builder_class_name}({class_name}):\n")
+            f.write(f"    # Required. The environment variable to indicate prebuilding the module when installing apex e.g. APEX_BUILD_FUSED_BIAS_SWIGLU for fused_bias_swiglu\n")
+            f.write(f"    BUILD_VAR = \"{build_var}\"\n")
+            f.write(f"    # Required. Either APEX_BUILD_CUDA_OPS or APEX_BUILD_CPU_OPS to indicate whether the module will be built for gpu or cpu\n")
+            f.write(f"    INCLUDE_FLAG = \"{include_flag}\"\n")
+            f.write(f"    # Required. Name of module e.g. fused_bias_swiglu\n")
+            f.write(f"    NAME = \"{module_name}\"\n")
+            f.write(f"\n")
+            f.write(f"    def __init__(self):\n")
+            f.write(f"        super().__init__(name=self.NAME)\n")
+            f.write(f"\n")
+            f.write(f"    # Required to override. Return the namespace where the module will be installed.\n")
+            f.write(f"    def absolute_name(self):\n")
+            f.write(f"        return f'apex.{{self.NAME}}'\n")
+            f.write(f"\n")
+            f.write(f"    # Required to override. Return the list of source files to be compiled\n")
+            f.write(f"    # Please mention the full path of the source files\n")
+            f.write(f"    # e.g. ['csrc/fused_dense_base.cpp', 'csrc/fused_dense_cuda.cu']\n")
+            f.write(f"    def sources(self):\n")
+            f.write(f"        return {sources_list_string}\n")  
+            f.write(f"\n")
+            f.write(f"    # Required to override. Return the list of include directories\n")
+            f.write(f"    # Please mention the full path of the include directories\n")
+            f.write(f"    # e.g. ['csrc', 'contrib/csrc']\n")
+            f.write(f"    def include_paths(self):\n")
+            f.write(f"        return {include_paths_string}\n")
+            f.write(f"\n")
+            f.write(f"    # Optional. Return a list of extra compiler flags for the C++ compiler when building C++ sources (e.g. optimization level, preprocessor macros).\n")
+            f.write(f"    def cxx_args(self):\n")
+            f.write(f"        return super().cxx_args() + self.generator_args() + self.version_dependent_macros()\n")
+            f.write(f"\n")
+            f.write(f"    # Optional. Return a list of extra compiler flags for nvcc when building CUDA sources (e.g. -O3, architecture flags, preprocessor macros).\n")
+            f.write(f"    def nvcc_args(self):\n")
+            f.write(f"        return super().nvcc_args() + ['-O3'] + self.version_dependent_macros()\n")
+            f.write(f"\n")
+            f.write(f"    # Optional. Return True if this module can be installed and loaded given the environment (e.g. minimum torch version supported).\n")
+            f.write(f"    def is_compatible(self, verbose=False):\n")
+            f.write(f"        return True\n")
+            f.write(f"\n")
+            f.write(f"    # Optional. Return list of libraries to compile against e.g. MIOpen.\n")
+            f.write(f"    def libraries_args(self):\n")
+            f.write(f"        return super().libraries_args()\n")
+
+        print(f"Builder module {module_name} created")
+
+
+    def add_jit_module(self, builder_name):
+        #check if builder module exists
+        is_builder_exists = self.check_if_builder_module_exists(builder_name)
+        if not is_builder_exists:
+            self.create_builder(builder_name)
+        else:
+            print(f"Builder module {builder_name} already exists")
+
+        #get module name from builder name
+        module_name = self.get_module_name(builder_name)
+        if module_name is None:
+            print(f"Module name for builder {builder_name} not found")
+            return
+
+        #if the loader module does not exist, create it
+        if not self.check_if_loader_module_exists(builder_name):
+            self.create_loader(builder_name)
+
+
+def main():
+    jit_module = JitModule()
+    if len(sys.argv) > 1:
+        module_name = sys.argv[1]
+    else:
+        module_name = input("What is the name of the module? ").strip()
+    if not module_name:
+        print("No module name provided.")
+        sys.exit(1)
+    success = jit_module.add_jit_module(module_name)
+    if success:
+        print("JIT module added")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* add code to add loader module for jit module

* fix errors to create jit module adder - use correct file name to save code to

* fix errors to create jit module adder - use correct class name of the builder and parameter to supply builder module name

* fix errors to create jit module loader

* add description about jit module script to add jit loader for a jit module with builder provided

* add description about jit module script to add jit loader for a jit module with builder provided

* add attributes and methods to override when creating a jit module builder

* add extra new lines

* update jit module to take the builder file name and extract module name from the builder, update missing entries in the table in readme for adding new module in jit

* refine the description about module to jit

* add description about jit

* add description about jit

* add code to create a builder based on user inputs

* change the example from fused_dense to swiglu

* allow user to skip sources list

* change description of cxx and nvcc flags, add description of methods and fields in the initial builder code created by script
