### PR TITLE
Add requirements for testing

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           docker exec apex-test-container bash -c "
             set -e
-            pip install expecttest onnxscript
+            pip install -r requirements_dev.txt
             pip install dist/apex-*.whl
           "
 

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -88,7 +88,7 @@ jobs:
           docker exec apex-build-container bash -c "
             set -eo pipefail
 
-            pip install expecttest onnxscript
+            pip install -r requirements_dev.txt
             pip install dist/apex-*.whl
 
             cd tests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 flake8>=3.7.9
 Sphinx>=3.0.3
+expecttest
+onnxscript


### PR DESCRIPTION
## Motivation

The CI script additionally installs expecttest onnxscript before running the test scripts. Moved these packages to requirements_dev.txt.

Addresses comment - https://github.com/ROCm/apex/pull/303#discussion_r2864489856

## Test Plan

Install the packages expecttest onnxscript through requirements_dev.txt and check if these packages are installed.

```
pip install -r requirements_dev.txt
pip list | grep onnxscript
pip list | grep expecttest 
```

Test the CI.

## Test Result

```
onnxscript                    0.5.4
expecttest                    0.3.0
```

Run - https://github.com/ROCm/apex/actions/runs/23505553410

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
