### PR TITLE
Check unit test pass/failure and handle timeout error in halo test

### DIFF
--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -30,6 +30,11 @@ def _sigabrt_handler(signum, frame):
     _force_exit(1)
 
 
+def _sigterm_handler(signum, frame):
+    """Handle SIGTERM from torchrun so surviving ranks exit immediately."""
+    _force_exit(1)
+
+
 def _timeout_handler(signum, frame):
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else "?"
     print(f"[rank{rank}] Test timed out after {TEST_TIMEOUT_SEC}s, exiting.", flush=True)
@@ -178,6 +183,7 @@ def main():
 
     signal.signal(signal.SIGALRM, _timeout_handler)
     signal.signal(signal.SIGABRT, _sigabrt_handler)
+    signal.signal(signal.SIGTERM, _sigterm_handler)
     signal.alarm(TEST_TIMEOUT_SEC)
 
     torch.distributed.init_process_group(

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -15,10 +15,25 @@ TEST_TIMEOUT_SEC = int(os.environ.get("TEST_TIMEOUT_SEC", "300"))
 NCCL_TIMEOUT_SEC = int(os.environ.get("NCCL_TIMEOUT_SEC", "120"))
 
 
+def _force_exit(code=1):
+    """Terminate immediately, bypassing Python cleanup.
+
+    When NCCL is in a broken state, its C++ watchdog thread will call
+    std::terminate() -> abort() -> SIGABRT on a separate thread.  We must
+    call os._exit() to beat that race; sys.exit() unwinds too slowly.
+    """
+    os._exit(code)
+
+
+def _sigabrt_handler(signum, frame):
+    """Catch SIGABRT from NCCL's C++ watchdog and convert to a clean exit."""
+    _force_exit(1)
+
+
 def _timeout_handler(signum, frame):
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else "?"
     print(f"[rank{rank}] Test timed out after {TEST_TIMEOUT_SEC}s, exiting.", flush=True)
-    sys.exit(1)
+    _force_exit(1)
 
 
 # Output of this function is used as ground truth in module tests.
@@ -162,6 +177,7 @@ def main():
     # for this trivial example peer_rank == rank and peer_group_size == world_size
 
     signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.signal(signal.SIGABRT, _sigabrt_handler)
     signal.alarm(TEST_TIMEOUT_SEC)
 
     torch.distributed.init_process_group(
@@ -184,14 +200,14 @@ def main():
         W_split_tests(1,64,200,336, half_halo,rank,world_size,halo_ex,num_steps)
     except torch.distributed.DistBackendError as e:
         print(f"[rank{rank}] Distributed backend error (likely NCCL timeout): {e}", flush=True)
-        sys.exit(1)
+        _force_exit(1)
     except RuntimeError as e:
         print(f"[rank{rank}] Runtime error: {e}", flush=True)
-        sys.exit(1)
-    finally:
-        signal.alarm(0)
-        if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+        _force_exit(1)
+
+    signal.alarm(0)
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -118,6 +118,9 @@ def single_test(peer_rank, peer_group_size, halo_ex, C, H, W, half_halo, dtype, 
     # peer memory flag sync relies on there being at least one barrier per step
     torch.distributed.barrier()
 
+    if peer_rank == 0:
+        torch.testing.assert_close(list_y, list_y2, msg=memory_format_str)
+
 
 def H_split_tests(N, C, H, W, half_halo, rank, world_size, halo_ex, num_steps):
     Hr = 8*world_size

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -1,3 +1,8 @@
+import os
+import sys
+import signal
+from datetime import timedelta
+
 import torch
 from apex.contrib.peer_memory import PeerMemoryPool, PeerHaloExchanger1d
 import peer_memory_cuda as pm
@@ -5,6 +10,15 @@ import peer_memory_cuda as pm
 # How to run:
 # torchrun --nproc_per_node <num-GPU> <this-python-prog>
 # <num-GPU> must be a power of 2 greater than 1.
+
+TEST_TIMEOUT_SEC = int(os.environ.get("TEST_TIMEOUT_SEC", "300"))
+NCCL_TIMEOUT_SEC = int(os.environ.get("NCCL_TIMEOUT_SEC", "120"))
+
+
+def _timeout_handler(signum, frame):
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else "?"
+    print(f"[rank{rank}] Test timed out after {TEST_TIMEOUT_SEC}s, exiting.", flush=True)
+    sys.exit(1)
 
 
 # Output of this function is used as ground truth in module tests.
@@ -147,7 +161,13 @@ def W_split_tests(N, C, H, W, half_halo, rank, world_size, halo_ex, num_steps):
 def main():
     # for this trivial example peer_rank == rank and peer_group_size == world_size
 
-    torch.distributed.init_process_group("nccl")
+    signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(TEST_TIMEOUT_SEC)
+
+    torch.distributed.init_process_group(
+        "nccl",
+        timeout=timedelta(seconds=NCCL_TIMEOUT_SEC),
+    )
     rank = torch.distributed.get_rank()
     world_size = torch.distributed.get_world_size()
     torch.cuda.set_device(rank)
@@ -159,8 +179,19 @@ def main():
     half_halo = 1
     halo_ex = PeerHaloExchanger1d(peer_ranks, rank, pool, half_halo)
 
-    H_split_tests(1,64,336,200, half_halo,rank,world_size,halo_ex,num_steps)
-    W_split_tests(1,64,200,336, half_halo,rank,world_size,halo_ex,num_steps)
+    try:
+        H_split_tests(1,64,336,200, half_halo,rank,world_size,halo_ex,num_steps)
+        W_split_tests(1,64,200,336, half_halo,rank,world_size,halo_ex,num_steps)
+    except torch.distributed.DistBackendError as e:
+        print(f"[rank{rank}] Distributed backend error (likely NCCL timeout): {e}", flush=True)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"[rank{rank}] Runtime error: {e}", flush=True)
+        sys.exit(1)
+    finally:
+        signal.alarm(0)
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Halo test takes more than 10 hours to run - https://github.com/ROCm/apex/actions/runs/23252552706/job/67612063034?pr=320

There is no graceful way to exit in case of timeout 
run - https://github.com/ROCm/apex/actions/runs/23505553410/job/68420328568

## Technical Details

To check for unit test failure, assert statement similar to nvidia apex is added -
https://github.com/NVIDIA/apex/blob/master/apex/contrib/test/peer_memory/test_peer_halo_exchange_module.py#L134.
```
torch.testing.assert_close(list_y, list_y2, msg=memory_format_str) 
```

The following changes are made to address timeout error:
1. Shorter timeout on init_process_group so failures surface faster, and timeout for the unit test
2. Try/except around test functions to catch DistBackendError
3. Proper cleanup with destroy_process_group in a finally block


## Test Plan

Run the halo test locally and check if it terminates within an hour.

```
pip uninstall apex 
make clean 
pip install . --no-build-isolation 
time torchrun --nproc_per_node 8 apex/contrib/peer_memory/peer_halo_exchange_module_tests.py   
```

Run the CI and check how much time the halo test takes with this change.

## Test Result

Run - https://github.com/ROCm/apex/actions/runs/23682504522
The halo test takes less than 1 hour.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
