### PR TITLE
[release/1.12.0] Cherry-pick: Fix 'Memory access fault' for fused dense on MI350 (#325)

### DIFF
--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -142,7 +142,7 @@ int gemm_lt(
 {
 
   hipStream_t stream;
-  hipblasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  hipblasHandle_t handle = at::cuda::getCurrentCUDABlasLtHandle();
   hipblasGetStream(handle, &stream);
 
 #if DEBUG


### PR DESCRIPTION
## Cherry-pick of #325 to release/1.12.0

**JIRA:** [ROCM-24646](https://amd-hub.atlassian.net/browse/ROCM-24646)
**Original PR:** https://github.com/ROCm/apex/pull/325
**Original commit:** af25af4e26f0546d897c3e2ff31502ef50530ecc

### Summary

Cherry-picks the fix for GPU memory access fault in `fused_dense_cuda` on MI350 (gfx950).

**Root cause:** `gemm_lt()` was using `at::cuda::getCurrentCUDABlasHandle()` (regular hipBLAS handle) instead of `at::cuda::getCurrentCUDABlasLtHandle()` (hipBLASLt handle) for hipBLASLt operations, causing a write-to-read-only-page fault.

**Fix:** Replace `getCurrentCUDABlasHandle()` with `getCurrentCUDABlasLtHandle()` in `gemm_lt()`.

[ROCM-24646]: https://amd-hub.atlassian.net/browse/ROCM-24646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ