### PR TITLE
Fix non-contiguous inputs in fused RoPE

### DIFF
--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -111,6 +111,12 @@ class FusedRoPEFuncAiter(FusedRoPEFunc):
         freqs: torch.Tensor,
         transpose_output_memory: bool = False,
     ) -> torch.Tensor:
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # input may be non-contiguous (e.g. transposed layout), so enforce
+        # contiguity here.
+        if t.stride(-1) != 1: t = t.contiguous()
+        # t = t.contiguous()
+
         s = t.shape[0]
         b = t.shape[1]
         h = t.shape[2]
@@ -136,6 +142,11 @@ class FusedRoPEFuncAiter(FusedRoPEFunc):
         ctx, grad_output: torch.Tensor
     ) -> Tuple[Union[torch.Tensor, None], ...]:
         (freqs,) = ctx.saved_tensors
+
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # incoming gradient may be non-contiguous (e.g. broadcast/expanded from
+        # a reduction such as `.sum()`), so enforce contiguity here.
+        if grad_output.stride(-1) != 1: grad_output = grad_output.contiguous()
 
         s = grad_output.shape[0]
         b = grad_output.shape[1]
@@ -238,6 +249,11 @@ class FusedRoPECachedFuncAiter(FusedRoPECachedFunc):
         sin_: torch.Tensor,
         transpose_output_memory: bool = False,
     ) -> torch.Tensor:
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # input may be non-contiguous (e.g. transposed layout), so enforce
+        # contiguity here.
+        if t.stride(-1) != 1: t = t.contiguous()
+
         s = t.shape[0]
         b = t.shape[1]
         h = t.shape[2]
@@ -262,6 +278,11 @@ class FusedRoPECachedFuncAiter(FusedRoPECachedFunc):
         ctx, grad_output: torch.Tensor
     ) -> Tuple[Union[torch.Tensor, None], ...]:
         cos_, sin_ = ctx.saved_tensors
+
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # incoming gradient may be non-contiguous (e.g. broadcast/expanded from
+        # a reduction such as `.sum()`), so enforce contiguity here.
+        if grad_output.stride(-1) != 1: grad_output = grad_output.contiguous()
 
         s = grad_output.shape[0]
         b = grad_output.shape[1]
@@ -360,6 +381,11 @@ class FusedRoPETHDFuncAiter(FusedRoPETHDFunc):
         cu_seqlens: torch.Tensor,
         freqs: torch.Tensor,
     ) -> torch.Tensor:
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # input may be non-contiguous (e.g. transposed layout), so enforce
+        # contiguity here.
+        if t.stride(-1) != 1: t = t.contiguous()
+
         t1 = t.shape[0]
         h = t.shape[1]
         d = t.shape[2]
@@ -378,6 +404,11 @@ class FusedRoPETHDFuncAiter(FusedRoPETHDFunc):
         ctx, grad_output: torch.Tensor
     ) -> Tuple[Union[torch.Tensor, None], ...]:
         cu_seqlens, freqs = ctx.saved_tensors
+
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # incoming gradient may be non-contiguous (e.g. broadcast/expanded from
+        # a reduction such as `.sum()`), so enforce contiguity here.
+        if grad_output.stride(-1) != 1: grad_output = grad_output.contiguous()
 
         t = grad_output.shape[0]
         h = grad_output.shape[1]
@@ -489,6 +520,11 @@ class FusedRoPE2DFuncAiter(FusedRoPE2DFunc):
         sin_w: torch.Tensor,
     ) -> torch.Tensor:
 
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # input may be non-contiguous (e.g. transposed layout), so enforce
+        # contiguity here.
+        if t.stride(-1) != 1: t = t.contiguous()
+
         s = t.shape[0]
         h = t.shape[2]
         d = t.shape[3]
@@ -509,6 +545,11 @@ class FusedRoPE2DFuncAiter(FusedRoPE2DFunc):
     ) -> Tuple[Union[torch.Tensor, None], ...]:
 
         cos_h, sin_h, cos_w, sin_w = ctx.saved_tensors
+
+        # The aiter kernel requires the head-dim (last) stride to be 1. The
+        # incoming gradient may be non-contiguous (e.g. broadcast/expanded from
+        # a reduction such as `.sum()`), so enforce contiguity here.
+        if grad_output.stride(-1) != 1: grad_output = grad_output.contiguous()
 
         s = grad_output.shape[0]
         h = grad_output.shape[2]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The aiter RoPE kernels require the head (last) dim to be unit-stride, but inputs
can arrive non-contiguous: transposed layouts in forward, and broadcast/expanded
gradients (e.g. from `.sum()`) in backward.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This enforces contiguity at the apex↔aiter boundary across all aiter RoPE variants
(standard, cached, THD, 2D), centralized in a single `_ensure_last_dim_contiguous`
helper that copies only when `stride(-1) != 1`, leaving outer strides untouched.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Run the fused RoPE tests on ROCm with the aiter backend enabled, exercising the
standard, cached, THD, and 2D variants (covers transposed inputs and the
`.sum()` reduction loss that produces broadcast/expanded gradients):
`USE_ROCM_AITER_ROPE_BACKEND=1 APEX_TEST_WITH_ROCM=1 python tests/L0/run_transformer/test_fused_rope.py`

## Test Result

<!-- Briefly summarize test outcomes. -->

- Before: `test_2d_forward_backward` aborts with
  `RuntimeError: rope_2d_bwd_impl requires all stride_d to be 1`.
- After: all RoPE forward/backward tests pass; fused vs. unfused outputs and
  gradients match within tolerance.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.